### PR TITLE
Add user agent in header

### DIFF
--- a/lib/lago/api/connection.rb
+++ b/lib/lago/api/connection.rb
@@ -39,7 +39,8 @@ module Lago
       def headers
         {
           'Authorization' => "Bearer #{api_key}",
-          'Content-Type' => 'application/json'
+          'Content-Type' => 'application/json',
+          'User-Agent' => "Lago Ruby v#{Lago::VERSION}"
         }
       end
 


### PR DESCRIPTION
Add user agent in headers sent to the API in order to allow the application to identify the source of a call