### PR TITLE
feat: add support for finding events by transaction id

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ event = {
 client.events.create(event)
 ```
 
+``` ruby
+transaction_id = "6afadc2a-f28c-40a4-a868-35636f229765"
+event = client.events.find(transaction_id)
+```
+
 ### Customers
 [Api reference](https://doc.getlago.com/docs/api/customers/customer-object)
 

--- a/lib/lago/api/connection.rb
+++ b/lib/lago/api/connection.rb
@@ -44,6 +44,17 @@ module Lago
         handle_response(response)
       end
 
+      def get(path)
+        response = http_client.send_request(
+          'GET',
+          path,
+          prepare_payload(nil),
+          headers
+        )
+
+        handle_response(response)
+      end
+
       private
 
       attr_reader :api_key, :uri

--- a/lib/lago/api/resources/event.rb
+++ b/lib/lago/api/resources/event.rb
@@ -17,6 +17,11 @@ module Lago
           connection.post(payload)
         end
 
+        def find(transaction_id)
+          uri = URI("#{client.base_api_url}#{api_resource}/#{transaction_id}")
+          connection.get(uri)
+        end
+
         def whitelist_params(params)
           {
             root_name => {

--- a/spec/lago/api/resources/event_spec.rb
+++ b/spec/lago/api/resources/event_spec.rb
@@ -29,4 +29,32 @@ RSpec.describe Lago::Api::Resources::Event do
       end
     end
   end
+
+  describe '#find' do
+    context 'when the event exists' do
+      before do
+        event_json = JSON.generate({'event' => factory_event.to_h})
+
+        stub_request(:get, 'https://api.getlago.com/api/v1/events/UNIQUE_ID')
+          .to_return(body: event_json, status: 200)
+      end
+
+      it 'returns the matching event if it exists' do
+        response = resource.find(factory_event.transaction_id)
+
+        expect(response['event']['transaction_id']).to eq factory_event.transaction_id
+      end
+    end
+
+    context 'when the event does not exist' do
+      before do
+        stub_request(:get, 'https://api.getlago.com/api/v1/events/DOESNOTEXIST')
+          .to_return(body: JSON.generate({status: 404, error: "Not Found"}), status: 404)
+      end
+
+      it 'raises an error' do
+        expect { resource.find('DOESNOTEXIST') }.to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds support for `client.events.find(transaction_id)`. Not sure if `find` is the best method name - suggestions for improvement are appreciated :)
