### PR TITLE
bug: fix HTTP response code type

### DIFF
--- a/lib/lago/api/connection.rb
+++ b/lib/lago/api/connection.rb
@@ -76,7 +76,7 @@ module Lago
       end
 
       def raise_error(response)
-        raise Lago::Api::HttpError.new(response.code, response.body, uri)
+        raise Lago::Api::HttpError.new(response.code.to_i, response.body, uri)
       end
     end
   end

--- a/spec/lago/api/connection_spec.rb
+++ b/spec/lago/api/connection_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Lago::Api::Connection do
+  subject(:connection) do
+    described_class.new(
+      'fake-api-key',
+      URI('https://testapi.example.org/')
+    )
+  end
+
+  context 'when an unsuccessful request is made' do
+    before do
+      stub_request(:post, 'https://testapi.example.org/NOTFOUND')
+        .to_return(status: 404, body: "")
+    end
+
+    it 'raises an exception with an integer error code' do
+      expect { connection.post({}, '/NOTFOUND') }.to raise_error { |exception|
+        expect(exception).to be_a(Lago::Api::HttpError)
+        expect(exception.error_code).to eq 404
+      }
+    end
+  end
+end


### PR DESCRIPTION
Ensure that Lago::Api::HttpError#error_code is an integer

Fixes #17 