### PR TITLE
feat: synchronous stripe customer creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ customer = {
     billing_configuration: {
         payment_provider: nil,
         provider_customer_id: nil,
+        sync: true,
     }
 }
 client.customers.create(customer)

--- a/lib/lago/api/resources/customer.rb
+++ b/lib/lago/api/resources/customer.rb
@@ -39,7 +39,7 @@ module Lago
         end
 
         def whitelist_billing_configuration(billing_params)
-          (billing_params || {}).slice(:payment_provider, :provider_customer_id)
+          (billing_params || {}).slice(:payment_provider, :provider_customer_id, :sync)
         end
       end
     end


### PR DESCRIPTION
Add a new `sync` flag in `customer[billing_configuration]` in order to allow synchronous creation of the stripe customer. It will return the stripe customer ID immediately rather by waiting for the webhook