### PR TITLE
feat: Add new customer current usage route

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,14 @@ customer = {
 client.customers.create(customer)
 ```
 
+```ruby
+customer_usage = client.customer.current_usage(customer_id)
+```
+
 ### Invoices
 [Api reference](https://doc.getlago.com/docs/api/invoices/invoice-object)
 
-``` ruby
+``` ruby`
 params = {
     lago_id: "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
     status: 'succeeded'

--- a/lib/lago/api/resources/customer.rb
+++ b/lib/lago/api/resources/customer.rb
@@ -12,6 +12,11 @@ module Lago
           'customer'
         end
 
+        def current_usage(customer_id)
+          uri = URI("#{client.base_api_url}#{api_resource}/#{customer_id}/current_usage")
+          connection.get(uri)
+        end
+
         def whitelist_params(params)
           result_hash = {
             customer_id: params[:customer_id],

--- a/spec/factories/customer_usage.rb
+++ b/spec/factories/customer_usage.rb
@@ -1,0 +1,30 @@
+FactoryBot.define do
+  factory :customer_usage, class: OpenStruct do
+    from_date { '2022-07-01' }
+    to_date { '2022-07-31' }
+    issuing_date { '2022-08-01' }
+    amount_cents { 123 }
+    amount_currency { 'EUR' }
+    total_amount_cents { 123 }
+    total_amount_currency { 'EUR' }
+    vat_amount_cents { 0 }
+    vat_amount_currency { 'EUR' }
+    charges_usage do
+      [{
+        'units': '1.0',
+        'amount_cents': 123,
+        'amount_currency': 'EUR',
+        'charge': {
+          'lago_id': '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba',
+          'charge_model': 'graduated'
+        },
+        'billable_metric': {
+          'lago_id': '99a6094e-199b-4101-896a-54e927ce7bd7',
+          'name': 'Usage metric',
+          'code': 'usage_metric',
+          'aggregation_type': 'sum'
+        }
+      }]
+    end
+  end
+end

--- a/spec/lago/api/resources/customer_spec.rb
+++ b/spec/lago/api/resources/customer_spec.rb
@@ -51,4 +51,45 @@ RSpec.describe Lago::Api::Resources::Customer do
       end
     end
   end
+
+  describe '#current_usage' do
+    let(:factory_customer_usage) { FactoryBot.build(:customer_usage) }
+
+    context 'when the customer exists' do
+      before do
+        usage_json = JSON.generate('customer_usage' => factory_customer_usage.to_h)
+
+        stub_request(:get, 'https://api.getlago.com/api/v1/customers/customer_id/current_usage')
+          .to_return(body: usage_json, status: 200)
+      end
+
+      it 'returns the usage of the customer' do
+        response = resource.current_usage('customer_id')
+
+        expect(response['customer_usage']['from_date']).to eq(factory_customer_usage.from_date)
+      end
+    end
+
+    context 'when the customer does not exists' do
+      before do
+        stub_request(:get, 'https://api.getlago.com/api/v1/customers/DOESNOTEXIST/current_usage')
+          .to_return(body: JSON.generate(status: 404, error: 'Not Found'), status: 404)
+      end
+
+      it 'raises an error' do
+        expect { resource.current_usage('DOESNOTEXIST') }.to raise_error
+      end
+    end
+
+    context 'when the customer does not have a subscription' do
+      before do
+        stub_request(:get, 'https://api.getlago.com/api/v1/customers/NOSUBSCRIPTION/current_usage')
+          .to_return(body: JSON.generate(status: 422, error: 'no_active_subscription'), status: 422)
+      end
+
+      it 'raises an error' do
+        expect { resource.current_usage('DOESNOTEXIST') }.to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add new `GET /api/v1/customers/:customer_id/current_usage` route

Related to:
- https://github.com/getlago/lago-api/pull/322
- https://github.com/getlago/lago-docs/pull/15