### PR TITLE
feat: Allow billing_time attribute for subscription creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ subscription = {
     subscription_id: "sub-id",
     name: "name",
     unique_id: "unique-id"
+    billing_time: "anniversary"
 }
 client.subscriptions.create(subscription)
 

--- a/lib/lago/api/resources/subscription.rb
+++ b/lib/lago/api/resources/subscription.rb
@@ -19,7 +19,8 @@ module Lago
               plan_code: params[:plan_code],
               name: params[:name],
               unique_id: params[:unique_id],
-              subscription_id: params[:subscription_id]
+              subscription_id: params[:subscription_id],
+              billing_time: params[:billing_time]
             }.compact
           }
         end

--- a/spec/factories/subscription.rb
+++ b/spec/factories/subscription.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     unique_id { 'sdwfzf-a71e-4ea2-bcf9-57d8885990ba' }
     plan_code { 'eartha lynch' }
     status { 'active' }
+    billing_time { 'calendar' }
     started_at { '2022-05-05T12:27:30Z' }
     terminated_at { nil }
     canceled_at { nil }

--- a/spec/lago/api/resources/subscription_spec.rb
+++ b/spec/lago/api/resources/subscription_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Lago::Api::Resources::Subscription do
         expect(subscription.plan_code).to eq(factory_subscription.plan_code)
         expect(subscription.status).to eq(factory_subscription.status)
         expect(subscription.unique_id).to eq(factory_subscription.unique_id)
+        expect(subscription.billing_time).to eq(factory_subscription.billing_time)
       end
     end
 

--- a/spec/lago/api/resources/subscription_spec.rb
+++ b/spec/lago/api/resources/subscription_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Lago::Api::Resources::Subscription do
         customer_id: factory_subscription.customer_id,
         plan_code: factory_subscription.plan_code,
         unique_id: factory_subscription.unique_id,
-        subscription_id: factory_subscription.subscription_id
+        subscription_id: factory_subscription.subscription_id,
+        billing_time: factory_subscription.billing_time
       }
     end
     let(:body) do


### PR DESCRIPTION
## Context

We want to add the ability to choose to bill users at subscription date anniversary and not only on a calendar basis.

## Changes

The objective of this pull request is to add the support for `billing_time` attribute for subscription creation

Possible values will be `anniversary` and `calendar`

The changes are :
- Accept the new `billing_time` argument into 'POST /subscriptions'

## Related resources

This PR follows:
- https://github.com/getlago/lago-api/pull/352 to update the subscription data model.
- https://github.com/getlago/lago-api/pull/360 to add a new date service for invoice bounds
- https://github.com/getlago/lago-api/pull/364 to expose billing time into GraphQL
- https://github.com/getlago/lago-api/pull/365 to expose billing time into API