### PR TITLE
Only use ssl when https

### DIFF
--- a/lib/lago/api/connection.rb
+++ b/lib/lago/api/connection.rb
@@ -90,7 +90,7 @@ module Lago
 
       def http_client
         http_client = Net::HTTP.new(uri.hostname, uri.port)
-        http_client.use_ssl = true
+        http_client.use_ssl = true if uri.scheme == 'https'
 
         http_client
       end


### PR DESCRIPTION
## Pull Request template

This change conditionally sets `use_ssl` on the http client when the URI scheme is https. Otherwise, the client will not work when developing locally and/or experimenting with the self-hosted instance.
