### PR TITLE
misc: Use external_id instead of customer_id and subscription_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ client = Lago::Api::Client.new({api_key: 'key'})
 ``` ruby
 event = {
     transaction_id: "__UNIQUE_ID__",
-    customer_id:  "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
+    external_customer_id:  "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
     code:  "code",
     timestamp:  1650893379,
     properties: {
@@ -39,7 +39,7 @@ client.events.create(event)
 
 event = {
     transaction_id: "__UNIQUE_ID__",
-    subscription_ids:  [
+    external_subscription_ids:  [
       "5eb02857-a71e-4ea2-bcf9-57d8885990ba", "5eb01117-a71e-4ea2-bcf9-57d8885990ba"
     ],
     code:  "code",
@@ -61,7 +61,7 @@ event = client.events.get(transaction_id)
 
 ``` ruby
 customer = {
-    customer_id: "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
+    external_id: "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
     address_line1: nil,
     address_line2: nil,
     city: nil,
@@ -86,7 +86,7 @@ client.customers.create(customer)
 ```
 
 ```ruby
-customer_usage = client.customer.current_usage(customer_id, subscription_id)
+customer_usage = client.customer.current_usage(external_customer_id, external_subscription_id)
 ```
 
 ### Invoices
@@ -110,11 +110,10 @@ client.invoices.download("5eb02857-a71e-4ea2-bcf9-57d8885990ba")
 
 ``` ruby
 subscription = {
-    customer_id: "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
+    external_customer_id: "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
     plan_code: "code",
-    subscription_id: "sub-id",
+    external_id: "sub-id",
     name: "name",
-    unique_id: "unique-id"
     billing_time: "anniversary"
 }
 client.subscriptions.create(subscription)
@@ -126,7 +125,7 @@ client.subscriptions.update(update_params, 'sub_id')
 
 client.subscriptions.destroy('sub_id')
 
-client.subscriptions.get_all({ customer_id: '123' })
+client.subscriptions.get_all({ external_customer_id: '123' })
 ```
 
 ### Applied coupons
@@ -134,7 +133,7 @@ client.subscriptions.get_all({ customer_id: '123' })
 
 ```ruby
 applied_coupon = {
-  customer_id: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+  external_customer_id: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
   coupon_code: "code",
   amount_cents: 123,
   amount_currency: "EUR"
@@ -148,7 +147,7 @@ client.applied_coupons.create(applied_coupon)
 
 ```ruby
 applied_add_on = {
-  customer_id: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+  external_customer_id: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
   add_on_code: "code",
   amount_cents: 123,
   amount_currency: "EUR"

--- a/lib/lago/api/resources/applied_add_on.rb
+++ b/lib/lago/api/resources/applied_add_on.rb
@@ -15,7 +15,7 @@ module Lago
         def whitelist_params(params)
           {
             root_name => {
-              customer_id: params[:customer_id],
+              external_customer_id: params[:external_customer_id],
               add_on_code: params[:add_on_code],
               amount_cents: params[:amount_cents],
               amount_currency: params[:amount_currency]

--- a/lib/lago/api/resources/applied_coupon.rb
+++ b/lib/lago/api/resources/applied_coupon.rb
@@ -15,7 +15,7 @@ module Lago
         def whitelist_params(params)
           {
             root_name => {
-              customer_id: params[:customer_id],
+              external_customer_id: params[:external_customer_id],
               coupon_code: params[:coupon_code],
               amount_cents: params[:amount_cents],
               amount_currency: params[:amount_currency]

--- a/lib/lago/api/resources/customer.rb
+++ b/lib/lago/api/resources/customer.rb
@@ -12,16 +12,16 @@ module Lago
           'customer'
         end
 
-        def current_usage(customer_id, subscription_id)
+        def current_usage(external_customer_id, external_subscription_id)
           uri = URI(
-            "#{client.base_api_url}#{api_resource}/#{customer_id}/current_usage?subscription_id=#{subscription_id}"
+            "#{client.base_api_url}#{api_resource}/#{external_customer_id}/current_usage?external_subscription_id=#{external_subscription_id}"
           )
           connection.get(uri, identifier: nil)
         end
 
         def whitelist_params(params)
           result_hash = {
-            customer_id: params[:customer_id],
+            external_customer_id: params[:external_customer_id],
             address_line1: params[:address_line1],
             address_line2: params[:address_line2],
             city: params[:city],

--- a/lib/lago/api/resources/event.rb
+++ b/lib/lago/api/resources/event.rb
@@ -28,10 +28,10 @@ module Lago
           {
             root_name => {
               transaction_id: params[:transaction_id],
-              customer_id: params[:customer_id],
+              external_customer_id: params[:external_customer_id],
               code: params[:code],
               timestamp: params[:timestamp],
-              subscription_id: params[:subscription_id],
+              external_subscription_id: params[:external_subscription_id],
               properties: params[:properties]
             }.compact
           }
@@ -41,10 +41,10 @@ module Lago
           {
             root_name => {
               transaction_id: params[:transaction_id],
-              customer_id: params[:customer_id],
+              external_customer_id: params[:external_customer_id],
               code: params[:code],
               timestamp: params[:timestamp],
-              subscription_ids: params[:subscription_ids],
+              external_subscription_ids: params[:external_subscription_ids],
               properties: params[:properties]
             }.compact
           }

--- a/lib/lago/api/resources/subscription.rb
+++ b/lib/lago/api/resources/subscription.rb
@@ -15,11 +15,10 @@ module Lago
         def whitelist_params(params)
           {
             root_name => {
-              customer_id: params[:customer_id],
+              external_customer_id: params[:external_customer_id],
               plan_code: params[:plan_code],
               name: params[:name],
-              unique_id: params[:unique_id],
-              subscription_id: params[:subscription_id],
+              external_id: params[:external_id],
               billing_time: params[:billing_time]
             }.compact
           }

--- a/spec/factories/applied_add_on.rb
+++ b/spec/factories/applied_add_on.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :applied_add_on, class: OpenStruct do
-    customer_id { '5eb02857-a71e-4ea2-bcf9-57d8881110ba' }
+    external_customer_id { '5eb02857-a71e-4ea2-bcf9-57d8881110ba' }
     add_on_code { '123' }
     amount_cents { 123 }
     amount_currency { 'EUR'}

--- a/spec/factories/applied_coupon.rb
+++ b/spec/factories/applied_coupon.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :applied_coupon, class: OpenStruct do
-    customer_id { '5eb02857-a71e-4ea2-bcf9-57d8885990ba' }
+    external_customer_id { '5eb02857-a71e-4ea2-bcf9-57d8885990ba' }
     coupon_code { '123' }
     amount_cents { 123 }
     amount_currency { 'EUR'}

--- a/spec/factories/customer.rb
+++ b/spec/factories/customer.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :customer, class: OpenStruct do
-    customer_id { '5eb02857-a71e-4ea2-bcf9-57d8885436ba' }
+    external_customer_id { '5eb02857-a71e-4ea2-bcf9-57d8885436ba' }
     name { 'Gavin Belson' }
     vat_rate { nil }
     country { 'US' }

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :event, class: OpenStruct do
     transaction_id { 'UNIQUE_ID' }
-    customer_id { '5eb02857-a71e-4ea2-bcf9-57d8885990ba' }
+    external_customer_id { '5eb02857-a71e-4ea2-bcf9-57d8885990ba' }
     code { '123' }
     timestamp { '2022-05-05T12:27:30Z' }
     properties do
@@ -13,7 +13,7 @@ FactoryBot.define do
 
   factory :batch_event, class: OpenStruct do
     transaction_id { 'UNIQUE_ID' }
-    subscription_ids { %w[5eb02857-a71e-4ea2-bcf9-57d8885990ba 5eb02857-a71e-4ea2-bcf9-57d8885990ba] }
+    external_subscription_ids { %w[5eb02857-a71e-4ea2-bcf9-57d8885990ba 5eb02857-a71e-4ea2-bcf9-57d8885990ba] }
     code { '123' }
     timestamp { '2022-05-05T12:27:30Z' }
     properties do

--- a/spec/factories/subscription.rb
+++ b/spec/factories/subscription.rb
@@ -2,9 +2,8 @@ FactoryBot.define do
   factory :subscription, class: OpenStruct do
     lago_id { 'b66b0c31-af01-4f3a-b4eb-017583c37831' }
     lago_customer_id { '5da14b2b-3a7c-4edc-a6df-fad2db464430' }
-    customer_id { '5eb02857-a71e-4ea2-bcf9-57d8885990ba' }
-    subscription_id { '1232857-a71e-4ea2-bcf9-57d8885990ba' }
-    unique_id { 'sdwfzf-a71e-4ea2-bcf9-57d8885990ba' }
+    external_customer_id { '5eb02857-a71e-4ea2-bcf9-57d8885990ba' }
+    external_id { '1232857-a71e-4ea2-bcf9-57d8885990ba' }
     plan_code { 'eartha lynch' }
     status { 'active' }
     billing_time { 'calendar' }

--- a/spec/lago/api/resources/applied_add_on_spec.rb
+++ b/spec/lago/api/resources/applied_add_on_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe Lago::Api::Resources::AppliedAddOn do
           'applied_add_on' => {
             'lago_id' => 'b7ab2926-1de8-4428-9bcd-779314ac129b',
             'lago_add_on_id' => 'b7ab2926-1de8-4428-9bcd-779314ac129b',
-
-            'customer_id' => factory_applied_add_on.customer_id,
+            'external_customer_id' => factory_applied_add_on.external_customer_id,
             'lago_customer_id' => '99a6094e-199b-4101-896a-54e927ce7bd7',
             'amount_cents' => 123,
             'amount_currency' => 'EUR',
@@ -41,7 +40,7 @@ RSpec.describe Lago::Api::Resources::AppliedAddOn do
       it 'returns an applied add-on' do
         applied_add_on = resource.create(params)
 
-        expect(applied_add_on.customer_id).to eq(factory_applied_add_on.customer_id)
+        expect(applied_add_on.external_customer_id).to eq(factory_applied_add_on.external_customer_id)
       end
     end
 

--- a/spec/lago/api/resources/applied_coupon_spec.rb
+++ b/spec/lago/api/resources/applied_coupon_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe Lago::Api::Resources::AppliedCoupon do
           'applied_coupon' => {
             'lago_id' => 'b7ab2926-1de8-4428-9bcd-779314ac129b',
             'lago_coupon_id' => 'b7ab2926-1de8-4428-9bcd-779314ac129b',
-
-            'customer_id' => factory_applied_coupon.customer_id,
+            'external_customer_id' => factory_applied_coupon.external_customer_id,
             'lago_customer_id' => '99a6094e-199b-4101-896a-54e927ce7bd7',
             'amount_cents' => 123,
             'amount_currency' => 'EUR',
@@ -43,7 +42,7 @@ RSpec.describe Lago::Api::Resources::AppliedCoupon do
       it 'returns an applied_coupon' do
         applied_coupon = resource.create(params)
 
-        expect(applied_coupon.customer_id).to eq(factory_applied_coupon.customer_id)
+        expect(applied_coupon.external_customer_id).to eq(factory_applied_coupon.external_customer_id)
       end
     end
 

--- a/spec/lago/api/resources/customer_spec.rb
+++ b/spec/lago/api/resources/customer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Lago::Api::Resources::Customer do
       it 'returns customer' do
         customer = resource.create(params)
 
-        expect(customer.customer_id).to eq(factory_customer.customer_id)
+        expect(customer.external_id).to eq(factory_customer.external_id)
         expect(customer.name).to eq(factory_customer.name)
         expect(customer.billing_configuration.provider_customer_id).to eq(factory_customer.billing_configuration[:provider_customer_id])
       end
@@ -59,12 +59,12 @@ RSpec.describe Lago::Api::Resources::Customer do
       before do
         usage_json = JSON.generate('customer_usage' => factory_customer_usage.to_h)
 
-        stub_request(:get, 'https://api.getlago.com/api/v1/customers/customer_id/current_usage?subscription_id=123')
+        stub_request(:get, 'https://api.getlago.com/api/v1/customers/external_customer_id/current_usage?external_subscription_id=123')
           .to_return(body: usage_json, status: 200)
       end
 
       it 'returns the usage of the customer' do
-        response = resource.current_usage('customer_id', '123')
+        response = resource.current_usage('external_customer_id', '123')
 
         expect(response['customer_usage']['from_date']).to eq(factory_customer_usage.from_date)
       end
@@ -72,7 +72,7 @@ RSpec.describe Lago::Api::Resources::Customer do
 
     context 'when the customer does not exists' do
       before do
-        stub_request(:get, 'https://api.getlago.com/api/v1/customers/DOESNOTEXIST/current_usage?subscription_id=123')
+        stub_request(:get, 'https://api.getlago.com/api/v1/customers/DOESNOTEXIST/current_usage?external_subscription_id=123')
           .to_return(body: JSON.generate(status: 404, error: 'Not Found'), status: 404)
       end
 
@@ -83,7 +83,7 @@ RSpec.describe Lago::Api::Resources::Customer do
 
     context 'when the customer does not have a subscription' do
       before do
-        stub_request(:get, 'https://api.getlago.com/api/v1/customers/NOSUBSCRIPTION/current_usage?subscription_id=123')
+        stub_request(:get, 'https://api.getlago.com/api/v1/customers/NOSUBSCRIPTION/current_usage?external_subscription_id=123')
           .to_return(body: JSON.generate(status: 422, error: 'no_active_subscription'), status: 422)
       end
 

--- a/spec/lago/api/resources/subscription_spec.rb
+++ b/spec/lago/api/resources/subscription_spec.rb
@@ -22,10 +22,9 @@ RSpec.describe Lago::Api::Resources::Subscription do
   describe '#create' do
     let(:params) do
       {
-        customer_id: factory_subscription.customer_id,
+        external_customer_id: factory_subscription.external_customer_id,
         plan_code: factory_subscription.plan_code,
-        unique_id: factory_subscription.unique_id,
-        subscription_id: factory_subscription.subscription_id,
+        external_id: factory_subscription.external_id,
         billing_time: factory_subscription.billing_time
       }
     end
@@ -45,10 +44,10 @@ RSpec.describe Lago::Api::Resources::Subscription do
       it 'returns subscription' do
         subscription = resource.create(params)
 
-        expect(subscription.customer_id).to eq(factory_subscription.customer_id)
+        expect(subscription.external_customer_id).to eq(factory_subscription.external_customer_id)
         expect(subscription.plan_code).to eq(factory_subscription.plan_code)
         expect(subscription.status).to eq(factory_subscription.status)
-        expect(subscription.unique_id).to eq(factory_subscription.unique_id)
+        expect(subscription.external_id).to eq(factory_subscription.external_id)
         expect(subscription.billing_time).to eq(factory_subscription.billing_time)
       end
     end
@@ -76,7 +75,7 @@ RSpec.describe Lago::Api::Resources::Subscription do
       it 'returns subscription' do
         subscription = resource.destroy('123')
 
-        expect(subscription.customer_id).to eq(factory_subscription.customer_id)
+        expect(subscription.external_customer_id).to eq(factory_subscription.external_customer_id)
         expect(subscription.plan_code).to eq(factory_subscription.plan_code)
         expect(subscription.status).to eq(factory_subscription.status)
       end
@@ -112,10 +111,10 @@ RSpec.describe Lago::Api::Resources::Subscription do
       it 'returns an subscription' do
         subscription = resource.update(params, '123')
 
-        expect(subscription.customer_id).to eq(factory_subscription.customer_id)
+        expect(subscription.external_customer_id).to eq(factory_subscription.external_customer_id)
         expect(subscription.plan_code).to eq(factory_subscription.plan_code)
         expect(subscription.status).to eq(factory_subscription.status)
-        expect(subscription.unique_id).to eq(factory_subscription.unique_id)
+        expect(subscription.external_id).to eq(factory_subscription.external_id)
       end
     end
 
@@ -148,17 +147,17 @@ RSpec.describe Lago::Api::Resources::Subscription do
       }.to_json
     end
 
-    context 'when customer_id is given' do
+    context 'when external_customer_id is given' do
       before do
-        stub_request(:get, 'https://api.getlago.com/api/v1/subscriptions?customer_id=123')
+        stub_request(:get, 'https://api.getlago.com/api/v1/subscriptions?external_customer_id=123')
           .to_return(body: response, status: 200)
       end
 
       it 'returns subscriptions on selected page' do
-        response = resource.get_all({ customer_id: '123' })
+        response = resource.get_all({ external_customer_id: '123' })
 
         expect(response['subscriptions'].first['lago_id']).to eq(factory_subscription.lago_id)
-        expect(response['subscriptions'].first['unique_id']).to eq(factory_subscription.unique_id)
+        expect(response['subscriptions'].first['external_id']).to eq(factory_subscription.external_id)
         expect(response['meta']['current_page']).to eq(1)
       end
     end


### PR DESCRIPTION
## Context

We want to clarify the difference between lago ids and external ids.

Today, we have `customer_id` on customers and `subscription_id|unique_id` on subscriptions.

On the API, the goal is to use external_ids:
- `external_id` or `external_customer_id` for customer
- `external_id` or `external_subscription_id` for subscription

## Description

The goal of this PR is to:
- rename `customer_id` to `external_id` on customers
- rename `subscription_id` to `external_id` on subscriptions
- remove `unique_id` from subscriptions
