### PR TITLE
feat (subscriptions): add support for subscription date

### DIFF
--- a/lib/lago/api/resources/subscription.rb
+++ b/lib/lago/api/resources/subscription.rb
@@ -19,7 +19,8 @@ module Lago
               plan_code: params[:plan_code],
               name: params[:name],
               external_id: params[:external_id],
-              billing_time: params[:billing_time]
+              billing_time: params[:billing_time],
+              subscription_date: params[:subscription_date],
             }.compact
           }
         end

--- a/spec/factories/subscription.rb
+++ b/spec/factories/subscription.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     status { 'active' }
     billing_time { 'calendar' }
     started_at { '2022-05-05T12:27:30Z' }
+    subscription_date { '2022-05-05' }
     terminated_at { nil }
     canceled_at { nil }
     created_at { '2022-05-05T12:27:30Z' }

--- a/spec/lago/api/resources/subscription_spec.rb
+++ b/spec/lago/api/resources/subscription_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Lago::Api::Resources::Subscription do
         external_customer_id: factory_subscription.external_customer_id,
         plan_code: factory_subscription.plan_code,
         external_id: factory_subscription.external_id,
+        subscription_date: factory_subscription.subscription_date,
         billing_time: factory_subscription.billing_time
       }
     end
@@ -48,6 +49,7 @@ RSpec.describe Lago::Api::Resources::Subscription do
         expect(subscription.plan_code).to eq(factory_subscription.plan_code)
         expect(subscription.status).to eq(factory_subscription.status)
         expect(subscription.external_id).to eq(factory_subscription.external_id)
+        expect(subscription.subscription_date).to eq(factory_subscription.subscription_date)
         expect(subscription.billing_time).to eq(factory_subscription.billing_time)
       end
     end


### PR DESCRIPTION
This PR adds support for `subscription_date` param when creating or updating subscription