### PR TITLE
misc: Move fields to billing configuration

### DIFF
--- a/lib/lago/api/resources/customer.rb
+++ b/lib/lago/api/resources/customer.rb
@@ -34,9 +34,8 @@ module Lago
             phone: params[:phone],
             state: params[:state],
             url: params[:url],
-            vat_rate: params[:vat_rate],
             zipcode: params[:zipcode],
-            currency: params[:currency]
+            currency: params[:currency],
           }
 
           whitelist_billing_configuration(params[:billing_configuration]).tap do |config|
@@ -47,7 +46,12 @@ module Lago
         end
 
         def whitelist_billing_configuration(billing_params)
-          (billing_params || {}).slice(:payment_provider, :provider_customer_id, :sync)
+          (billing_params || {}).slice(
+            :payment_provider,
+            :provider_customer_id,
+            :sync,
+            :vat_rate,
+          )
         end
       end
     end

--- a/lib/lago/api/resources/organization.rb
+++ b/lib/lago/api/resources/organization.rb
@@ -13,22 +13,31 @@ module Lago
         end
 
         def whitelist_params(params)
-          {
-            root_name => {
-              webhook_url: params[:webhook_url],
-              vat_rate: params[:vat_rate],
-              country: params[:country],
-              address_line1: params[:address_line1],
-              address_line2: params[:address_line2],
-              state: params[:state],
-              zipcode: params[:zipcode],
-              email: params[:email],
-              city: params[:city],
-              legal_name: params[:legal_name],
-              legal_number: params[:legal_number],
-              invoice_footer: params[:invoice_footer]
-            }.compact
-          }
+          result_hash = {
+            webhook_url: params[:webhook_url],
+            country: params[:country],
+            address_line1: params[:address_line1],
+            address_line2: params[:address_line2],
+            state: params[:state],
+            zipcode: params[:zipcode],
+            email: params[:email],
+            city: params[:city],
+            legal_name: params[:legal_name],
+            legal_number: params[:legal_number],
+          }.compact
+
+          whitelist_billing_configuration(params[:billing_configuration]).tap do |config|
+            result_hash[:billing_configuration] = config unless config.empty?
+          end
+
+          { root_name => result_hash }
+        end
+
+        def whitelist_billing_configuration(billing_params)
+          (billing_params || {}).slice(
+            :invoice_footer,
+            :vat_rate,
+          )
         end
       end
     end

--- a/spec/factories/customer.rb
+++ b/spec/factories/customer.rb
@@ -2,10 +2,9 @@ FactoryBot.define do
   factory :customer, class: OpenStruct do
     external_customer_id { '5eb02857-a71e-4ea2-bcf9-57d8885436ba' }
     name { 'Gavin Belson' }
-    vat_rate { nil }
     country { 'US' }
     address_line1 { '5230 Penfield Ave' }
-    address_line2 {'fzufuzfuz' }
+    address_line2 { 'fzufuzfuz' }
     state { 'CA' }
     zipcode { '91364' }
     email { 'dinesh@piedpiper.test' }
@@ -19,6 +18,7 @@ FactoryBot.define do
       {
         payment_provider: 'stripe',
         provider_customer_id: 'cus_123456',
+        vat_rate: nil,
       }
     end
     currency { 'EUR' }

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :organization, class: OpenStruct do
     webhook_url { 'http://example.com/webhooks/' }
-    vat_rate { 20 }
     country { 'country' }
     address_line1 { 'line1' }
     address_line2 { 'line2' }
@@ -11,6 +10,11 @@ FactoryBot.define do
     city { 'city' }
     legal_name { 'legal1' }
     legal_number { 'legal2' }
-    invoice_footer { 'footer' }
+    billing_configuration do
+      {
+        invoice_footer: 'footer',
+        vat_rate: 20,
+      }
+    end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Description

The goal of this PR is to move fields related to Billing or Invoice into `billing_configuration`.

For customer: `vat_rate`.

For organization: `invoice_footer`, `vat_rate`.
