### PR TITLE
feat(timezones): Update clients to support customer timezones

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lago-ruby-client (0.15.1.pre.alpha)
+    lago-ruby-client (0.18.0.pre.alpha)
       jwt
       openssl
 

--- a/lib/lago/api/resources/coupon.rb
+++ b/lib/lago/api/resources/coupon.rb
@@ -25,8 +25,8 @@ module Lago
               frequency: params[:frequency],
               frequency_duration: params[:frequency_duration],
               expiration: params[:expiration],
-              expiration_date: params[:expiration_date]
-            }.compact
+              expiration_at: params[:expiration_at],
+            }.compact,
           }
         end
       end

--- a/lib/lago/api/resources/customer.rb
+++ b/lib/lago/api/resources/customer.rb
@@ -36,6 +36,7 @@ module Lago
             url: params[:url],
             zipcode: params[:zipcode],
             currency: params[:currency],
+            timezone: params[:timezone],
           }
 
           whitelist_billing_configuration(params[:billing_configuration]).tap do |config|

--- a/lib/lago/api/resources/organization.rb
+++ b/lib/lago/api/resources/organization.rb
@@ -24,6 +24,7 @@ module Lago
             city: params[:city],
             legal_name: params[:legal_name],
             legal_number: params[:legal_number],
+            timezone: params[:timezone],
           }.compact
 
           whitelist_billing_configuration(params[:billing_configuration]).tap do |config|

--- a/lib/lago/api/resources/wallet.rb
+++ b/lib/lago/api/resources/wallet.rb
@@ -20,8 +20,8 @@ module Lago
               name: params[:name],
               paid_credits: params[:paid_credits],
               granted_credits: params[:granted_credits],
-              expiration_date: params[:expiration_date]
-            }.compact
+              expiration_at: params[:expiration_at],
+            }.compact,
           }
         end
       end

--- a/spec/factories/coupon.rb
+++ b/spec/factories/coupon.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :coupon, class: OpenStruct do
     name { 'coupon_name' }
     code { 'coupon_code' }
-    expiration_date { '2022-08-08' }
+    expiration_at { '2022-08-08T23:59:59Z' }
     expiration { 'no_expiration' }
     amount_cents { 200 }
     amount_currency { 'EUR' }

--- a/spec/factories/customer.rb
+++ b/spec/factories/customer.rb
@@ -23,5 +23,6 @@ FactoryBot.define do
       }
     end
     currency { 'EUR' }
+    timezone { 'Europe/Paris' }
   end
 end

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -16,5 +16,6 @@ FactoryBot.define do
         vat_rate: 20,
       }
     end
+    timezone { 'America/New_York' }
   end
 end

--- a/spec/factories/wallet.rb
+++ b/spec/factories/wallet.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :wallet, class: OpenStruct do
     name { 'wallet name' }
     external_customer_id { '12345' }
-    expiration_date { '2022-07-07' }
+    expiration_at { '2022-07-07T23:59:59Z' }
     rate_amount { '1' }
     paid_credits { '100' }
     granted_credits { '100' }

--- a/spec/lago/api/resources/coupon_spec.rb
+++ b/spec/lago/api/resources/coupon_spec.rb
@@ -16,19 +16,19 @@ RSpec.describe Lago::Api::Resources::Coupon do
         'amount_cents' => factory_coupon.amount_cents,
         'amount_currency' => factory_coupon.amount_currency,
         'expiration' => factory_coupon.expiration,
-        'expiration_date' => factory_coupon.expiration_date,
+        'expiration_at' => factory_coupon.expiration_at,
         'coupon_type' => factory_coupon.coupon_type,
         'frequency' => factory_coupon.frequency,
         'reusable' => factory_coupon.reusable,
-        'created_at' => '2022-04-29T08:59:51Z'
-      }
+        'created_at' => '2022-04-29T08:59:51Z',
+      },
     }.to_json
   end
   let(:error_response) do
     {
       'status' => 422,
       'error' => 'Unprocessable Entity',
-      'message' => 'Validation error on the record'
+      'message' => 'Validation error on the record',
     }.to_json
   end
 
@@ -36,7 +36,7 @@ RSpec.describe Lago::Api::Resources::Coupon do
     let(:params) { factory_coupon.to_h }
     let(:body) do
       {
-        'coupon' => factory_coupon.to_h
+        'coupon' => factory_coupon.to_h,
       }
     end
 
@@ -72,7 +72,7 @@ RSpec.describe Lago::Api::Resources::Coupon do
     let(:params) { factory_coupon.to_h }
     let(:body) do
       {
-        'coupon' => factory_coupon.to_h
+        'coupon' => factory_coupon.to_h,
       }
     end
 
@@ -169,7 +169,7 @@ RSpec.describe Lago::Api::Resources::Coupon do
             'description' => factory_coupon.description,
             'aggregation_type' => factory_coupon.aggregation_type,
             'field_name' => factory_coupon.field_name,
-            'created_at' => '2022-04-29T08:59:51Z'
+            'created_at' => '2022-04-29T08:59:51Z',
           }
         ],
         'meta': {
@@ -177,7 +177,7 @@ RSpec.describe Lago::Api::Resources::Coupon do
           'next_page' => 2,
           'prev_page' => nil,
           'total_pages' => 7,
-          'total_count' => 63
+          'total_count' => 63,
         }
       }.to_json
     end

--- a/spec/lago/api/resources/customer_spec.rb
+++ b/spec/lago/api/resources/customer_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Lago::Api::Resources::Customer do
       end
 
       it 'raises an error' do
-        expect { resource.current_usage('DOESNOTEXIST', '123') }.to raise_error
+        expect { resource.current_usage('DOESNOTEXIST', '123') }.to raise_error Lago::Api::HttpError
       end
     end
 

--- a/spec/lago/api/resources/event_spec.rb
+++ b/spec/lago/api/resources/event_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Lago::Api::Resources::Event do
       end
 
       it 'raises an error' do
-        expect { resource.get('DOESNOTEXIST') }.to raise_error
+        expect { resource.get('DOESNOTEXIST') }.to raise_error Lago::Api::HttpError
       end
     end
   end

--- a/spec/lago/api/resources/wallet_spec.rb
+++ b/spec/lago/api/resources/wallet_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe Lago::Api::Resources::Wallet do
         'lago_id' => 'this-is-lago-id',
         'lago_customer_id' => factory_wallet.id,
         'name' => factory_wallet.name,
-        'expiration_date' => factory_wallet.expiration_date,
+        'expiration_at' => factory_wallet.expiration_at,
         'balance' => 100,
         'rate_amount' => factory_wallet.rate_amount,
-        'created_at' => '2022-04-29T08:59:51Z'
+        'created_at' => '2022-04-29T08:59:51Z',
       }
     }.to_json
   end
@@ -24,7 +24,7 @@ RSpec.describe Lago::Api::Resources::Wallet do
     {
       'status' => 422,
       'error' => 'Unprocessable Entity',
-      'message' => 'Validation error on the record'
+      'message' => 'Validation error on the record',
     }.to_json
   end
 
@@ -32,7 +32,7 @@ RSpec.describe Lago::Api::Resources::Wallet do
     let(:params) { factory_wallet.to_h }
     let(:body) do
       {
-        'wallet' => factory_wallet.to_h
+        'wallet' => factory_wallet.to_h,
       }
     end
 
@@ -69,7 +69,7 @@ RSpec.describe Lago::Api::Resources::Wallet do
     let(:id) { 'id' }
     let(:body) do
       {
-        'wallet' => { name: 'new-name' }
+        'wallet' => { name: 'new-name' },
       }
     end
 
@@ -167,11 +167,11 @@ RSpec.describe Lago::Api::Resources::Wallet do
             'lago_id' => 'this-is-lago-id',
             'external_customer_id' => factory_wallet.external_customer_id,
             'name' => factory_wallet.name,
-            'expiration_date' => factory_wallet.expiration_date,
+            'expiration_at' => factory_wallet.expiration_at,
             'paid_credits' => factory_wallet.paid_credits,
             'granted_credits' => factory_wallet.granted_credits,
             'rate_amount' => factory_wallet.rate_amount,
-            'created_at' => '2022-04-29T08:59:51Z'
+            'created_at' => '2022-04-29T08:59:51Z',
           }
         ],
         'meta': {
@@ -179,7 +179,7 @@ RSpec.describe Lago::Api::Resources::Wallet do
           'next_page' => 2,
           'prev_page' => nil,
           'total_pages' => 7,
-          'total_count' => 63
+          'total_count' => 63,
         }
       }.to_json
     end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR adds:
- Support for timezone at customer level
- Support for timezone at organization level
- Replace `expiration_date` by `expiration_at` on coupons
- Replace `expiration_date` by `expiration_at` on wallets
