### PR TITLE
fix (webhooks): add support for new webhook secret response payload

### DIFF
--- a/lib/lago/api/resources/webhook.rb
+++ b/lib/lago/api/resources/webhook.rb
@@ -15,15 +15,11 @@ module Lago
         def public_key
           path = '/api/v1/webhooks/public_key'
 
-          response = connection.get(path, identifier: nil)
+          response = connection.get(path, identifier: nil)[root_name]
 
-          # Adding fallback for text/plain Content-Type response in older versions
-          if response.is_a?(String)
-            OpenSSL::PKey::RSA.new(Base64.decode64(response))
-          else
-            webhook_details = JSON.parse(response[root_name].to_json, object_class: OpenStruct)
-            OpenSSL::PKey::RSA.new(Base64.decode64(webhook_details.public_key))
-          end
+          webhook_details = JSON.parse(response.to_json, object_class: OpenStruct)
+
+          OpenSSL::PKey::RSA.new(Base64.decode64(webhook_details.public_key))
         end
 
         def valid_signature?(signature, webhook_payload, cached_key = public_key)

--- a/lib/lago/api/resources/webhook.rb
+++ b/lib/lago/api/resources/webhook.rb
@@ -8,11 +8,18 @@ module Lago
           'webhooks'
         end
 
+        def root_name
+          'webhook'
+        end
+
         def public_key
           path = '/api/v1/webhooks/public_key'
 
-          webhooks_public_key = connection.get(path, identifier: nil)
-          OpenSSL::PKey::RSA.new(Base64.decode64(webhooks_public_key))
+          response = connection.get(path, identifier: nil)[root_name]
+
+          webhook_details = JSON.parse(response.to_json, object_class: OpenStruct)
+
+          OpenSSL::PKey::RSA.new(Base64.decode64(webhook_details.public_key))
         end
 
         def valid_signature?(signature, webhook_payload, cached_key = public_key)

--- a/lib/lago/api/resources/webhook.rb
+++ b/lib/lago/api/resources/webhook.rb
@@ -13,7 +13,7 @@ module Lago
         end
 
         def public_key
-          path = '/api/v1/webhooks/public_key'
+          path = '/api/v1/webhooks/json_public_key'
 
           response = connection.get(path, identifier: nil)[root_name]
 

--- a/spec/lago/api/resources/webhook_spec.rb
+++ b/spec/lago/api/resources/webhook_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Lago::Api::Resources::Webhook do
   end
 
   before do
-    stub_request(:get, 'https://api.getlago.com/api/v1/webhooks/public_key')
+    stub_request(:get, 'https://api.getlago.com/api/v1/webhooks/json_public_key')
       .to_return(body: response, status: 200)
   end
 

--- a/spec/lago/api/resources/webhook_spec.rb
+++ b/spec/lago/api/resources/webhook_spec.rb
@@ -14,12 +14,17 @@ RSpec.describe Lago::Api::Resources::Webhook do
 
   let(:private_key) { OpenSSL::PKey::RSA.new(private_key_string) }
   let(:public_key) { private_key.public_key }
-
-  let(:public_key_response) { Base64.encode64(public_key.to_s) }
+  let(:response) do
+    {
+      'webhook' => {
+        'public_key' => Base64.encode64(public_key.to_s),
+      },
+    }.to_json
+  end
 
   before do
     stub_request(:get, 'https://api.getlago.com/api/v1/webhooks/public_key')
-      .to_return(body: public_key_response, status: 200)
+      .to_return(body: response, status: 200)
   end
 
   describe 'public_key' do


### PR DESCRIPTION
`/api/v1/webhooks/public_key` endpoint changed reponse to json format:
{'webhook': {'public_key': 'public key encoded'}}

This PR adds support for mentioned changes