### PR TITLE
feat: Add support for grace period

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lago-ruby-client (0.19.0.pre.alpha)
+    lago-ruby-client (0.19.4.pre.alpha)
       jwt
       openssl
 

--- a/lib/lago/api/resources/credit_note.rb
+++ b/lib/lago/api/resources/credit_note.rb
@@ -40,7 +40,7 @@ module Lago
           path = "/api/v1/credit_notes/#{credit_note_id}/download"
           response = connection.post({}, path)
 
-          JSON.parse(response.to_json, object_class: OpenStruct)
+          JSON.parse(response.to_json, object_class: OpenStruct).credit_note
         end
 
         def void(credit_note_id)
@@ -51,7 +51,7 @@ module Lago
             body: {}
           )
 
-          JSON.parse(response.to_json, object_class: OpenStruct)
+          JSON.parse(response.to_json, object_class: OpenStruct).credit_note
         end
       end
     end

--- a/lib/lago/api/resources/customer.rb
+++ b/lib/lago/api/resources/customer.rb
@@ -48,6 +48,7 @@ module Lago
 
         def whitelist_billing_configuration(billing_params)
           (billing_params || {}).slice(
+            :invoice_grace_period,
             :payment_provider,
             :provider_customer_id,
             :sync,

--- a/lib/lago/api/resources/invoice.rb
+++ b/lib/lago/api/resources/invoice.rb
@@ -26,6 +26,13 @@ module Lago
           JSON.parse(response.to_json, object_class: OpenStruct).invoice
         end
 
+        def finalize(invoice_id)
+          path = "/api/v1/invoices/#{invoice_id}/finalize"
+          response = connection.put(path, identifier: nil, body: {})
+
+          JSON.parse(response.to_json, object_class: OpenStruct).invoice
+        end
+
         def whitelist_params(params)
           {
             root_name => {

--- a/lib/lago/api/resources/invoice.rb
+++ b/lib/lago/api/resources/invoice.rb
@@ -16,14 +16,14 @@ module Lago
           path = "/api/v1/invoices/#{invoice_id}/download"
           response = connection.post({}, path)
 
-          JSON.parse(response.to_json, object_class: OpenStruct)
+          JSON.parse(response.to_json, object_class: OpenStruct).invoice
         end
 
         def refresh(invoice_id)
           path = "/api/v1/invoices/#{invoice_id}/refresh"
           response = connection.put(path, identifier: nil, body: {})
 
-          JSON.parse(response.to_json, object_class: OpenStruct)
+          JSON.parse(response.to_json, object_class: OpenStruct).invoice
         end
 
         def whitelist_params(params)

--- a/lib/lago/api/resources/invoice.rb
+++ b/lib/lago/api/resources/invoice.rb
@@ -19,6 +19,13 @@ module Lago
           JSON.parse(response.to_json, object_class: OpenStruct)
         end
 
+        def refresh(invoice_id)
+          path = "/api/v1/invoices/#{invoice_id}/refresh"
+          response = connection.put(path, identifier: nil, body: {})
+
+          JSON.parse(response.to_json, object_class: OpenStruct)
+        end
+
         def whitelist_params(params)
           {
             root_name => {

--- a/lib/lago/api/resources/organization.rb
+++ b/lib/lago/api/resources/organization.rb
@@ -37,6 +37,7 @@ module Lago
         def whitelist_billing_configuration(billing_params)
           (billing_params || {}).slice(
             :invoice_footer,
+            :invoice_grace_period,
             :vat_rate,
           )
         end

--- a/spec/factories/customer.rb
+++ b/spec/factories/customer.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
     legal_number { '49-008-2965' }
     billing_configuration do
       {
+        invoice_grace_period: 3,
         payment_provider: 'stripe',
         provider_customer_id: 'cus_123456',
         vat_rate: nil,

--- a/spec/factories/invoice.rb
+++ b/spec/factories/invoice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :invoice, class: OpenStruct do
     lago_id { 'this_is_lago_internal_id' }
@@ -6,6 +8,7 @@ FactoryBot.define do
     to_date { '2022-06-02' }
     issuing_date { '2022-06-02' }
     invoice_type { 'type1' }
+    status { 'finalized' }
     payment_status { 'succeeded' }
     amount_cents { 100 }
     amount_currency { 'EUR' }

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     billing_configuration do
       {
         invoice_footer: 'footer',
+        invoice_grace_period: 2,
         vat_rate: 20,
       }
     end

--- a/spec/lago/api/resources/credit_note_spec.rb
+++ b/spec/lago/api/resources/credit_note_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Lago::Api::Resources::CreditNote do
     {
       'status' => 404,
       'error' => 'Not Found',
-      'code' => 'credit_note_not_found'
+      'code' => 'credit_note_not_found',
     }
   end
 
@@ -21,7 +21,7 @@ RSpec.describe Lago::Api::Resources::CreditNote do
     {
       'status' => 422,
       'error' => 'Unprocessable Entity',
-      'message' => 'Validation error on the record'
+      'message' => 'Validation error on the record',
     }.to_json
   end
 
@@ -34,21 +34,19 @@ RSpec.describe Lago::Api::Resources::CreditNote do
           {
             fee_id: 'some-lago-fee-id-1',
             credit_amount_cents: 10,
-            refund_amount_cents: 5
+            refund_amount_cents: 5,
           },
           {
             fee_id: 'some-lago-fee-id-2',
             credit_amount_cents: 5,
-            refund_amount_cents: 10
-          }
-        ]
+            refund_amount_cents: 10,
+          },
+        ],
       }
     end
 
     let(:response_body) do
-      {
-        'credit_note' => credit_note.to_h
-      }
+      { 'credit_note' => credit_note.to_h }
     end
 
     context 'when credit note is successfully created' do
@@ -80,16 +78,12 @@ RSpec.describe Lago::Api::Resources::CreditNote do
 
   describe '#update' do
     let(:params) do
-      {
-        refund_status: 'pending'
-      }
+      { refund_status: 'pending' }
     end
 
     let(:request_body) do
       {
-        'credit_note' => {
-          'refund_status' => credit_note.refund_status
-        }
+        'credit_note' => { 'refund_status' => credit_note.refund_status },
       }
     end
 
@@ -122,9 +116,7 @@ RSpec.describe Lago::Api::Resources::CreditNote do
 
   describe '#get' do
     let(:response_body) do
-      {
-        'credit_note' => credit_note.to_h
-      }
+      { 'credit_note' => credit_note.to_h }
     end
 
     context 'when credit note is successfully fetched' do
@@ -162,8 +154,8 @@ RSpec.describe Lago::Api::Resources::CreditNote do
           'next_page' => nil,
           'prev_page' => nil,
           'total_pages' => 1,
-          'total_count' => 1
-        }
+          'total_count' => 1,
+        },
       }
     end
 
@@ -182,9 +174,7 @@ RSpec.describe Lago::Api::Resources::CreditNote do
 
   describe '#download' do
     let(:response_body) do
-      {
-        'credit_note' => credit_note.to_h
-      }
+      { 'credit_note' => credit_note.to_h }
     end
 
     before do
@@ -196,15 +186,13 @@ RSpec.describe Lago::Api::Resources::CreditNote do
     it 'returns a credit_note' do
       response = resource.download('123456')
 
-      expect(response.lago_id).to eq(credit_note.id)
+      expect(response.lago_id).to eq(credit_note.lago_id)
     end
   end
 
   describe '#void' do
     let(:response_body) do
-      {
-        'credit_note' => credit_note.to_h
-      }
+      { 'credit_note' => credit_note.to_h }
     end
 
     before do
@@ -216,7 +204,7 @@ RSpec.describe Lago::Api::Resources::CreditNote do
     it 'returns a credit_note' do
       response = resource.void('123456')
 
-      expect(response.lago_id).to eq(credit_note.id)
+      expect(response.lago_id).to eq(credit_note.lago_id)
     end
   end
 end

--- a/spec/lago/api/resources/customer_spec.rb
+++ b/spec/lago/api/resources/customer_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Lago::Api::Resources::Customer do
   subject(:resource) { described_class.new(client) }
+
   let(:client) { Lago::Api::Client.new }
   let(:factory_customer) { FactoryBot.build(:customer) }
 
@@ -11,7 +12,7 @@ RSpec.describe Lago::Api::Resources::Customer do
     let(:params) { factory_customer.to_h }
     let(:body) do
       {
-        'customer' => factory_customer.to_h
+        'customer' => factory_customer.to_h,
       }
     end
 
@@ -28,6 +29,7 @@ RSpec.describe Lago::Api::Resources::Customer do
         expect(customer.external_id).to eq(factory_customer.external_id)
         expect(customer.name).to eq(factory_customer.name)
         expect(customer.currency).to eq(factory_customer.currency)
+        expect(customer.billing_configuration.invoice_grace_period).to eq(factory_customer.billing_configuration[:invoice_grace_period])
         expect(customer.billing_configuration.provider_customer_id).to eq(factory_customer.billing_configuration[:provider_customer_id])
       end
     end
@@ -37,7 +39,7 @@ RSpec.describe Lago::Api::Resources::Customer do
         {
           'status' => 422,
           'error' => 'Unprocessable Entity',
-          'message' => 'Validation error on the record'
+          'message' => 'Validation error on the record',
         }.to_json
       end
 
@@ -48,7 +50,7 @@ RSpec.describe Lago::Api::Resources::Customer do
       end
 
       it 'raises an error' do
-        expect { resource.create(params) }.to raise_error Lago::Api::HttpError
+        expect { resource.create(params) }.to raise_error(Lago::Api::HttpError)
       end
     end
   end

--- a/spec/lago/api/resources/invoice_spec.rb
+++ b/spec/lago/api/resources/invoice_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Lago::Api::Resources::Invoice do
     it 'returns invoice' do
       invoice = resource.download('123456')
 
-      expect(invoice.lago_id).to eq(factory_invoice.id)
+      expect(invoice.lago_id).to eq(factory_invoice.lago_id)
     end
   end
 
@@ -176,7 +176,7 @@ RSpec.describe Lago::Api::Resources::Invoice do
       end
 
       it 'returns invoice' do
-        invoice = resource.refresh(lago_id).invoice
+        invoice = resource.refresh(lago_id)
 
         expect(invoice.lago_id).to eq(factory_invoice.lago_id)
         expect(invoice.status).to eq(factory_invoice.status)

--- a/spec/lago/api/resources/invoice_spec.rb
+++ b/spec/lago/api/resources/invoice_spec.rb
@@ -163,4 +163,24 @@ RSpec.describe Lago::Api::Resources::Invoice do
       expect(invoice.lago_id).to eq(factory_invoice.id)
     end
   end
+
+  describe '#refresh' do
+    let(:response_body) do
+      { 'invoice' => factory_invoice.to_h }
+    end
+
+    context 'when payment status is successfully updated' do
+      before do
+        stub_request(:put, "https://api.getlago.com/api/v1/invoices/#{lago_id}/refresh")
+          .with(body: {}).to_return(body: response_body.to_json, status: 200)
+      end
+
+      it 'returns invoice' do
+        invoice = resource.refresh(lago_id).invoice
+
+        expect(invoice.lago_id).to eq(factory_invoice.lago_id)
+        expect(invoice.status).to eq(factory_invoice.status)
+      end
+    end
+  end
 end

--- a/spec/lago/api/resources/invoice_spec.rb
+++ b/spec/lago/api/resources/invoice_spec.rb
@@ -169,18 +169,34 @@ RSpec.describe Lago::Api::Resources::Invoice do
       { 'invoice' => factory_invoice.to_h }
     end
 
-    context 'when payment status is successfully updated' do
-      before do
-        stub_request(:put, "https://api.getlago.com/api/v1/invoices/#{lago_id}/refresh")
-          .with(body: {}).to_return(body: response_body.to_json, status: 200)
-      end
+    before do
+      stub_request(:put, "https://api.getlago.com/api/v1/invoices/#{lago_id}/refresh")
+        .with(body: {}).to_return(body: response_body.to_json, status: 200)
+    end
 
-      it 'returns invoice' do
-        invoice = resource.refresh(lago_id)
+    it 'returns invoice' do
+      invoice = resource.refresh(lago_id)
 
-        expect(invoice.lago_id).to eq(factory_invoice.lago_id)
-        expect(invoice.status).to eq(factory_invoice.status)
-      end
+      expect(invoice.lago_id).to eq(factory_invoice.lago_id)
+      expect(invoice.status).to eq(factory_invoice.status)
+    end
+  end
+
+  describe '#finalize' do
+    let(:response_body) do
+      { 'invoice' => factory_invoice.to_h }
+    end
+
+    before do
+      stub_request(:put, "https://api.getlago.com/api/v1/invoices/#{lago_id}/finalize")
+        .with(body: {}).to_return(body: response_body.to_json, status: 200)
+    end
+
+    it 'returns invoice' do
+      invoice = resource.finalize(lago_id)
+
+      expect(invoice.lago_id).to eq(factory_invoice.lago_id)
+      expect(invoice.status).to eq(factory_invoice.status)
     end
   end
 end

--- a/spec/lago/api/resources/organization_spec.rb
+++ b/spec/lago/api/resources/organization_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe Lago::Api::Resources::Organization do
   let(:factory_organization) { FactoryBot.build(:organization) }
   let(:response) do
     {
-      'organization' => factory_organization.to_h
+      'organization' => factory_organization.to_h,
     }.to_json
   end
   let(:error_response) do
     {
       'status' => 422,
       'error' => 'Unprocessable Entity',
-      'message' => 'Validation error on the record'
+      'message' => 'Validation error on the record',
     }.to_json
   end
 
@@ -24,13 +24,13 @@ RSpec.describe Lago::Api::Resources::Organization do
     let(:params) { factory_organization.to_h }
     let(:body) do
       {
-        'organization' => factory_organization.to_h
+        'organization' => factory_organization.to_h,
       }
     end
 
     context 'when organization is successfully updated' do
       before do
-        stub_request(:put, "https://api.getlago.com/api/v1/organizations")
+        stub_request(:put, 'https://api.getlago.com/api/v1/organizations')
           .with(body: body)
           .to_return(body: response, status: 200)
       end
@@ -39,6 +39,7 @@ RSpec.describe Lago::Api::Resources::Organization do
         organization = resource.update(params)
 
         expect(organization.webhook_url).to eq(factory_organization.webhook_url)
+        expect(organization.billing_configuration.invoice_grace_period).to eq(factory_organization.billing_configuration[:invoice_grace_period])
       end
     end
 
@@ -50,7 +51,7 @@ RSpec.describe Lago::Api::Resources::Organization do
       end
 
       it 'raises an error' do
-        expect { resource.update(params) }.to raise_error Lago::Api::HttpError
+        expect { resource.update(params) }.to raise_error(Lago::Api::HttpError)
       end
     end
   end


### PR DESCRIPTION
The goal of this PR is to:
- add `invoice_grace_period` to organization
- add `invoice_grace_period` to customer
- add `status` to invoice
- add endpoint for refreshing an invoice
- add endpoint for finalizing an invoice