### PR TITLE
feat(delete_bm): Update tests for billable metric deletion

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lago-ruby-client (0.19.4.pre.alpha)
+    lago-ruby-client (0.20.0.pre.beta)
       jwt
       openssl
 

--- a/spec/lago/api/resources/billable_metric_spec.rb
+++ b/spec/lago/api/resources/billable_metric_spec.rb
@@ -22,9 +22,12 @@ RSpec.describe Lago::Api::Resources::BillableMetric do
           'key' => 'region',
           'values' => %w[france italy spain],
         },
+        'active_subscriptions_count' => 0,
+        'draft_invoice_count' => 0,
       },
     }.to_json
   end
+
   let(:error_response) do
     {
       'status' => 422,

--- a/spec/lago/api/resources/billable_metric_spec.rb
+++ b/spec/lago/api/resources/billable_metric_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Lago::Api::Resources::BillableMetric do
           'values' => %w[france italy spain],
         },
         'active_subscriptions_count' => 0,
-        'draft_invoice_count' => 0,
+        'draft_invoices_count' => 0,
       },
     }.to_json
   end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/179

## Context

As a user, I want to be able to delete a billable metric that is linked to a subscription in case of a change of pricing (e.g. we no longer charge customers based on the number of API calls).

Once deleted, the corresponding charges will be removed from the plans and from all draft invoices.

Deleted metrics will still be included in past invoices (i.e. finalized invoices).

## Description

The goal of this PR is to add on the billable metric response:
- `activeSubscriptionsCount`
- `draftInvoicesCount`

These fields are used to know the impact of deleting billable metric.