### PR TITLE
feat(delete_plan): Add subscription and invoice counters to plans

### DIFF
--- a/LICENSE copy
+++ b/LICENSE copy
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Lago
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a ruby wrapper for Lago API
 
 [![Gem Version](https://badge.fury.io/rb/lago-ruby-client.svg)](https://badge.fury.io/rb/lago-ruby-client)
-[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://spdx.org/licenses/MIT.html)
 
 ## Installation
 
@@ -43,4 +43,4 @@ The contribution documentation is available [here](https://github.com/getlago/la
 
 ## License
 
-Lago Ruby client is distributed under [AGPL-3.0](LICENSE).
+Lago Ruby client is distributed under [MIT license](LICENSE).

--- a/spec/lago/api/resources/plan_spec.rb
+++ b/spec/lago/api/resources/plan_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Lago::Api::Resources::Plan do
         'trial_period' => 2,
         'pay_in_advance' => false,
         'bill_charges_monthly' => false,
+        'active_subscriptions_count' => 0,
+        'draft_invoices_count' => 0,
         'charges' => [
           {
             'lago_id' => 'id1',
@@ -37,7 +39,7 @@ RSpec.describe Lago::Api::Resources::Plan do
     {
       'status' => 422,
       'error' => 'Unprocessable Entity',
-      'message' => 'Validation error on the record'
+      'message' => 'Validation error on the record',
     }.to_json
   end
 
@@ -45,7 +47,7 @@ RSpec.describe Lago::Api::Resources::Plan do
     let(:params) { factory_plan.to_h }
     let(:body) do
       {
-        'plan' => factory_plan.to_h
+        'plan' => factory_plan.to_h,
       }
     end
 
@@ -81,7 +83,7 @@ RSpec.describe Lago::Api::Resources::Plan do
     let(:params) { factory_plan.to_h }
     let(:body) do
       {
-        'plan' => factory_plan.to_h
+        'plan' => factory_plan.to_h,
       }
     end
 
@@ -183,6 +185,8 @@ RSpec.describe Lago::Api::Resources::Plan do
             'trial_period' => 2,
             'pay_in_advance' => false,
             'bill_charges_monthly' => false,
+            'active_subscriptions_count' => 0,
+            'draft_invoices_count' => 0,
             'charges' => [
               {
                 'lago_id' => 'id',
@@ -200,7 +204,7 @@ RSpec.describe Lago::Api::Resources::Plan do
           'next_page' => 2,
           'prev_page' => nil,
           'total_pages' => 7,
-          'total_count' => 63
+          'total_count' => 63,
         }
       }.to_json
     end


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete plans.

The goal of this feature is to be able to soft-delete a plan linked to an active or terminated subscription.

## Description

The goal of this PR is to add two counters in the plan response:
- `active_subscription_count`
- `draft_invoice_count`