### PR TITLE
feat(delete_coupon): Ability to destroy an applied coupon

### DIFF
--- a/lib/lago/api/resources/applied_coupon.rb
+++ b/lib/lago/api/resources/applied_coupon.rb
@@ -12,6 +12,13 @@ module Lago
           'applied_coupon'
         end
 
+        def destroy(external_customer_id, coupon_code)
+          path = "/api/v1/customers/#{external_customer_id}/coupons"
+          response = connection.destroy(path, identifier: coupon_code)[root_name]
+
+          JSON.parse(response.to_json, object_class: OpenStruct)
+        end
+
         def whitelist_params(params)
           {
             root_name => {
@@ -21,8 +28,8 @@ module Lago
               percentage_rate: params[:percentage_rate],
               frequency: params[:frequency],
               frequency_duration: params[:frequency_duration],
-              amount_currency: params[:amount_currency]
-            }.compact
+              amount_currency: params[:amount_currency],
+            }.compact,
           }
         end
       end


### PR DESCRIPTION
**Context**
Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete an applied coupon.

**Description**
This PR adds the destroy endpoint for applied coupon.