### PR TITLE
feat(instant_charge): Ability to have an instant charge

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lago-ruby-client (0.26.0.pre.beta)
+    lago-ruby-client (0.27.0.pre.beta)
       jwt
       openssl
 
@@ -19,8 +19,8 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    debug (1.6.3)
-      irb (>= 1.3.6)
+    debug (1.7.2)
+      irb (>= 1.5.0)
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
     factory_bot (6.2.1)
@@ -28,8 +28,8 @@ GEM
     hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    io-console (0.5.11)
-    irb (1.4.2)
+    io-console (0.6.0)
+    irb (1.6.3)
       reline (>= 0.3.0)
     jwt (2.7.0)
     minitest (5.18.0)
@@ -41,7 +41,7 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.3.1)
-    reline (0.3.1)
+    reline (0.3.3)
       io-console (~> 0.5)
     rexml (3.2.5)
     rspec (3.11.0)

--- a/lib/lago/api/resources/plan.rb
+++ b/lib/lago/api/resources/plan.rb
@@ -36,7 +36,7 @@ module Lago
           processed_charges = []
 
           charges.each do |c|
-            result = (c || {}).slice(:id, :billable_metric_id, :charge_model, :properties, :group_properties)
+            result = (c || {}).slice(:id, :billable_metric_id, :charge_model, :instant, :properties, :group_properties)
 
             processed_charges << result unless result.empty?
           end

--- a/spec/factories/plan.rb
+++ b/spec/factories/plan.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
         {
           billable_metric_id: 'id',
           charge_model: 'standard',
+          instant: false,
           properties: { amount: '0.22' },
         },
       ]

--- a/spec/lago/api/resources/plan_spec.rb
+++ b/spec/lago/api/resources/plan_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Lago::Api::Resources::Plan do
             'billable_metric_code' => 'bm_code',
             'created_at' => '2022-04-29T08:59:51Z',
             'charge_model' => factory_plan.charges.first[:charge_model],
+            'instant' => false,
             'properties' => factory_plan.charges.first[:properties],
           },
         ]
@@ -195,6 +196,7 @@ RSpec.describe Lago::Api::Resources::Plan do
                 'billable_metric_code' => 'bm_code',
                 'created_at' => '2022-04-29T08:59:51Z',
                 'charge_model' => factory_plan.charges.first[:charge_model],
+                'instant' => false,
                 'properties' => factory_plan.charges.first[:properties],
                 'group_properties' => [],
               }


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR allows having an instant charge.