### PR TITLE
feat(bm): Expose count of attached plans

### DIFF
--- a/spec/lago/api/resources/billable_metric_spec.rb
+++ b/spec/lago/api/resources/billable_metric_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Lago::Api::Resources::BillableMetric do
         },
         'active_subscriptions_count' => 0,
         'draft_invoices_count' => 0,
+        'plans_count' => 0,
       },
     }.to_json
   end

--- a/spec/lago/api/resources/plan_spec.rb
+++ b/spec/lago/api/resources/plan_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Lago::Api::Resources::Plan do
           {
             'lago_id' => 'id1',
             'lago_billable_metric_id' => factory_plan.charges.first[:lago_billable_metric_id],
+            'billable_metric_code' => 'bm_code',
             'created_at' => '2022-04-29T08:59:51Z',
             'charge_model' => factory_plan.charges.first[:charge_model],
             'properties' => factory_plan.charges.first[:properties],
@@ -191,6 +192,7 @@ RSpec.describe Lago::Api::Resources::Plan do
               {
                 'lago_id' => 'id',
                 'lago_billable_metric_id' => factory_plan.charges.first[:lago_billable_metric_id],
+                'billable_metric_code' => 'bm_code',
                 'created_at' => '2022-04-29T08:59:51Z',
                 'charge_model' => factory_plan.charges.first[:charge_model],
                 'properties' => factory_plan.charges.first[:properties],


### PR DESCRIPTION
## Context

Plans edition has some issue if you update some properties of a billable metric, especially if you change groups definition or aggregation type :

"After the billable metric edition, new dimensions are created with new group_id that do not match the ones in the plans already defined"

## Description

This PR exposes a new `plans_count` field in the `BillableMetric` response type to let the API users know if the BM is editable.

Related to https://github.com/getlago/lago-api/pull/914
