### PR TITLE
feat(instant_charge): Add API route to estimate instant fees amount

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lago-ruby-client (0.23.0.pre.beta)
+    lago-ruby-client (0.26.0.pre.beta)
       jwt
       openssl
 

--- a/lib/lago/api/resources/event.rb
+++ b/lib/lago/api/resources/event.rb
@@ -24,6 +24,13 @@ module Lago
           connection.post(payload, uri)
         end
 
+        def estimate_fees(params)
+          uri = URI("#{client.base_api_url}#{api_resource}/estimate_fees")
+
+          payload = whitelist_estimate_params(params)
+          connection.post(payload, uri)
+        end
+
         def whitelist_params(params)
           {
             root_name => {
@@ -32,8 +39,8 @@ module Lago
               code: params[:code],
               timestamp: params[:timestamp],
               external_subscription_id: params[:external_subscription_id],
-              properties: params[:properties]
-            }.compact
+              properties: params[:properties],
+            }.compact,
           }
         end
 
@@ -45,8 +52,19 @@ module Lago
               code: params[:code],
               timestamp: params[:timestamp],
               external_subscription_ids: params[:external_subscription_ids],
-              properties: params[:properties]
-            }.compact
+              properties: params[:properties],
+            }.compact,
+          }
+        end
+
+        def whitelist_estimate_params(params)
+          {
+            root_name => {
+              code: params[:code],
+              external_customer_id: params[:external_customer_id],
+              external_subscription_id: params[:external_subscription_id],
+              properties: params[:properties],
+            }.compact,
           }
         end
       end

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -22,4 +22,15 @@ FactoryBot.define do
       }
     end
   end
+
+  factory :estimate_fees_event, class: OpenStruct do
+    external_customer_id { '5eb02857-a71e-4ea2-bcf9-57d8885990ba' }
+    external_subscription_id { '5eb02857-a71e-4ea2-bcf9-57d8885990ba' }
+    code { '123' }
+    properties do
+      {
+        'custom_field' => 'custom',
+      }
+    end
+  end
 end

--- a/spec/lago/api/resources/event_spec.rb
+++ b/spec/lago/api/resources/event_spec.rb
@@ -81,4 +81,27 @@ RSpec.describe Lago::Api::Resources::Event do
       end
     end
   end
+
+  describe '#estimate_fees' do
+    let(:factory_event) { FactoryBot.build(:estimate_fees_event) }
+    let(:event_body) { { 'event' => factory_event.to_h } }
+
+    let(:response_body) do
+      { 'fees' => [FactoryBot.build(:fee)] }
+    end
+
+    context 'when event is successfully processed' do
+      before do
+        stub_request(:post, 'https://api.getlago.com/api/v1/events/estimate_fees')
+          .with(body: event_body)
+          .to_return(body: response_body.to_json, status: 200)
+      end
+
+      it 'returns a list of fees' do
+        response = resource.estimate_fees(factory_event.to_h)
+
+        expect(response['fees'].count).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/instantly-charge-the-customer-when-an-event-is-processed

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds the new `POST api/v1/events/estimate_fees` route

Related to https://github.com/getlago/lago-api/pull/923
