### PR TITLE
feat(instant_charge): Expose fees updapte and get all routes

### DIFF
--- a/lib/lago/api/resources/fee.rb
+++ b/lib/lago/api/resources/fee.rb
@@ -11,6 +11,14 @@ module Lago
         def root_name
           'fee'
         end
+
+        def whitelist_params(params)
+          {
+            root_name => {
+              payment_status: params[:payment_status],
+            },
+          }
+        end
       end
     end
   end

--- a/spec/factories/fee.rb
+++ b/spec/factories/fee.rb
@@ -2,8 +2,10 @@
 
 FactoryBot.define do
   factory :fee, class: OpenStruct do
-    lago_id { 'this_is_lago_internal_id' }
-    lago_group_id { 'this_is_lago_group_internal_id' }
+    lago_id { 'b82f64f2-3360-4a1a-a800-6d3489e73c04' }
+    lago_group_id { 'b82f64f2-3360-4a1a-a800-6d3489e73c04' }
+    lago_invoice_id { 'b82f64f2-3360-4a1a-a800-6d3489e73c04' }
+    external_subscription_id { 'external-id' }
     amount_cents { 120 }
     amount_currency { 'EUR' }
     vat_amount_cents { 20 }
@@ -12,6 +14,7 @@ FactoryBot.define do
     total_amount_currency { 'EUR' }
     units { '10.0' }
     events_count { 10 }
+    payment_status { 'succeeded' }
 
     association :item, factory: :fee_item
   end
@@ -20,5 +23,7 @@ FactoryBot.define do
     type { 'charge' }
     code { 'fee_code' }
     name { 'Fee Name' }
+    lago_item_id { 'b82f64f2-3360-4a1a-a800-6d3489e73c04' }
+    item_type { 'AddOn' }
   end
 end

--- a/spec/lago/api/resources/fee_spec.rb
+++ b/spec/lago/api/resources/fee_spec.rb
@@ -46,4 +46,95 @@ RSpec.describe Lago::Api::Resources::Fee do
       end
     end
   end
+
+  describe '#get_all' do
+    let(:response) do
+      {
+        'fees' => [
+          factory_fee.to_h,
+        ],
+        'meta' => {
+          'current_page' => 1,
+          'next_page' => 2,
+          'prev_page' => nil,
+          'total_pages' => 7,
+          'total_count' => 63,
+        },
+      }.to_json
+    end
+
+    context 'without filters' do
+      before do
+        stub_request(:get, 'https://api.getlago.com/api/v1/fees')
+          .to_return(body: response, status: 200)
+      end
+
+      it 'returns fees of the first page' do
+        response = resource.get_all
+
+        expect(response['fees'].first['lago_id']).to eq(factory_fee.lago_id)
+      end
+
+      context 'when filters are present' do
+        before do
+          stub_request(:get, 'https://api.getlago.com/api/v1/fees?per_page=2&page=1')
+            .to_return(body: response, status: 200)
+        end
+
+        it 'returns fees on selected page' do
+          response = resource.get_all(per_page: 2, page: 1)
+
+          expect(response['fees'].first['lago_id']).to eq(factory_fee.lago_id)
+          expect(response['meta']['current_page']).to eq(1)
+        end
+      end
+
+      context 'when response is not a 200' do
+        before do
+          stub_request(:get, 'https://api.getlago.com/api/v1/fees')
+            .to_return(body: error_response, status: 404)
+        end
+
+        it 'raises an error' do
+          expect { resource.get_all }.to raise_error(Lago::Api::HttpError)
+        end
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:params) do
+      { payment_status: 'succeeded' }
+    end
+
+    let(:request_body) do
+      { 'fee' => { 'payment_status' => factory_fee.payment_status } }
+    end
+
+    context 'when fee is successfully updated' do
+      before do
+        stub_request(:put, "https://api.getlago.com/api/v1/fees/#{lago_id}")
+          .with(body: request_body)
+          .to_return(body: response_body.to_json, status: 200)
+      end
+
+      it 'returns a fee' do
+        fee = resource.update(params, lago_id)
+
+        expect(fee.lago_id).to eq(factory_fee.lago_id)
+      end
+    end
+
+    context 'when invoice is not successfully updated' do
+      before do
+        stub_request(:put, "https://api.getlago.com/api/v1/fees/#{lago_id}")
+          .with(body: request_body)
+          .to_return(body: error_response, status: 422)
+      end
+
+      it 'raises an error' do
+        expect { resource.update(params, lago_id) }.to raise_error(Lago::Api::HttpError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/instantly-charge-the-customer-when-an-event-is-processed

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds:
- Definition for `GET /api/v1/fees`
- Definition for `PUT /api/v1/fees/:id`
- Add new fields definition to fees:
  - lago_invoice_id
  - external_subscription_id
  - payment_status
  - created_at
  - succeeded_at
  - failed_at
  - refunded_at
  - item[lago_item_id]
  - item[item_type]