### PR TITLE
feat(invoice): Refactoring on invoice amounts

### DIFF
--- a/spec/factories/invoice.rb
+++ b/spec/factories/invoice.rb
@@ -4,18 +4,21 @@ FactoryBot.define do
   factory :invoice, class: OpenStruct do
     lago_id { 'this_is_lago_internal_id' }
     sequential_id { 16 }
-    from_date { '2022-06-02' }
-    to_date { '2022-06-02' }
+    number { "LAG-16" }
+    version_number { '2' }
     issuing_date { '2022-06-02' }
-    invoice_type { 'type1' }
+    invoice_type { 'subscription' }
     status { 'finalized' }
     payment_status { 'succeeded' }
-    amount_cents { 100 }
-    amount_currency { 'EUR' }
+    currency { 'EUR' }
+    fees_amount_cents { 100 }
     vat_amount_cents { 20 }
-    vat_amount_currency { 'EUR' }
-    total_amount_cents { 120 }
-    total_amount_currency { 'EUR' }
+    coupons_amount_cents { 5 }
+    credit_notes_amount_cents { 5 }
+    sub_total_vat_excluded_amount_cents { 100 }
+    sub_total_vat_included_amount_cents { 120 }
+    total_amount_cents { 110 }
+    prepaid_credit_amount_cents { 0 }
     file_url { 'http://file.url' }
     metadata do
       [


### PR DESCRIPTION
Update `Invoice` definition:

## New fields
- `currency`
- `fees_amount_cents`
- `coupons_amount_cents`
- `credit_notes_amount_cents`
- `sub_total_vat_excluded_amount_cents`
- `sub_total_vat_included_amount_cents`
- `prepaid_credit_amount_cents`


## Deprecated fields
- `legacy`
- `amount_currency`
- `vat_amount_currency`
- `credit_amount_currency`
- `total_amount_currency`
- `amount_cents`
- `credit_amount_cents`
