### PR TITLE
feat(min_charge): Ability to specify a minimum amount for a charge

### DIFF
--- a/lib/lago/api/resources/plan.rb
+++ b/lib/lago/api/resources/plan.rb
@@ -36,7 +36,15 @@ module Lago
           processed_charges = []
 
           charges.each do |c|
-            result = (c || {}).slice(:id, :billable_metric_id, :charge_model, :instant, :properties, :group_properties)
+            result = (c || {}).slice(
+              :id,
+              :billable_metric_id,
+              :charge_model,
+              :instant,
+              :min_amount_cents,
+              :properties,
+              :group_properties,
+            )
 
             processed_charges << result unless result.empty?
           end

--- a/spec/factories/fee.rb
+++ b/spec/factories/fee.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     lago_id { 'b82f64f2-3360-4a1a-a800-6d3489e73c04' }
     lago_group_id { 'b82f64f2-3360-4a1a-a800-6d3489e73c04' }
     lago_invoice_id { 'b82f64f2-3360-4a1a-a800-6d3489e73c04' }
+    lago_true_up_fee_id { 'b82f64f2-3360-4a1a-a800-6d3489e73c04' }
     external_subscription_id { 'external-id' }
     amount_cents { 120 }
     amount_currency { 'EUR' }

--- a/spec/factories/plan.rb
+++ b/spec/factories/plan.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
           billable_metric_id: 'id',
           charge_model: 'standard',
           instant: false,
+          min_amount_cents: 0,
           properties: { amount: '0.22' },
         },
       ]

--- a/spec/lago/api/resources/plan_spec.rb
+++ b/spec/lago/api/resources/plan_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Lago::Api::Resources::Plan do
             'created_at' => '2022-04-29T08:59:51Z',
             'charge_model' => factory_plan.charges.first[:charge_model],
             'instant' => false,
+            'min_amount_cents' => 0,
             'properties' => factory_plan.charges.first[:properties],
           },
         ]
@@ -197,6 +198,7 @@ RSpec.describe Lago::Api::Resources::Plan do
                 'created_at' => '2022-04-29T08:59:51Z',
                 'charge_model' => factory_plan.charges.first[:charge_model],
                 'instant' => false,
+                'min_amount_cents' => 0,
                 'properties' => factory_plan.charges.first[:properties],
                 'group_properties' => [],
               }


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-minimum-fees

## Context

We want to allow users to set spendings minimum on usage-based charges.

## Description

The goal of this PR is to:
- add min_amount_cents to Charge
- add lago_true_up_fee_id to Fee