### PR TITLE
fix: update support for download invoice and credit note

### DIFF
--- a/lib/lago/api/resources/credit_note.rb
+++ b/lib/lago/api/resources/credit_note.rb
@@ -40,6 +40,8 @@ module Lago
           path = "/api/v1/credit_notes/#{credit_note_id}/download"
           response = connection.post({}, path)
 
+          return response unless response.is_a?(Hash)
+
           JSON.parse(response.to_json, object_class: OpenStruct).credit_note
         end
 

--- a/lib/lago/api/resources/invoice.rb
+++ b/lib/lago/api/resources/invoice.rb
@@ -23,6 +23,8 @@ module Lago
           path = "/api/v1/invoices/#{invoice_id}/download"
           response = connection.post({}, path)
 
+          return response unless response.is_a?(Hash)
+
           JSON.parse(response.to_json, object_class: OpenStruct).invoice
         end
 

--- a/spec/lago/api/resources/invoice_spec.rb
+++ b/spec/lago/api/resources/invoice_spec.rb
@@ -219,6 +219,20 @@ RSpec.describe Lago::Api::Resources::Invoice do
 
       expect(invoice.lago_id).to eq(factory_invoice.lago_id)
     end
+
+    context 'when invoice has not been generated yet' do
+      before do
+        stub_request(:post, 'https://api.getlago.com/api/v1/invoices/123456/download')
+          .with(body: {})
+          .to_return(body: '', status: 200)
+      end
+
+      it 'returns true' do
+        result = resource.download('123456')
+
+        expect(result).to eq(true)
+      end
+    end
   end
 
   describe '#refresh' do


### PR DESCRIPTION
When `download` action is triggered for `invoice` or `credit_note` collection, there are 2 scenarios:

1. File has already been generated and invoice object is returned
2. File has not been generated yet; Job is scheduled and empty response is returned