### PR TITLE
Allow currency param for wallet

### DIFF
--- a/lib/lago/api/resources/wallet.rb
+++ b/lib/lago/api/resources/wallet.rb
@@ -20,6 +20,7 @@ module Lago
               name: params[:name],
               paid_credits: params[:paid_credits],
               granted_credits: params[:granted_credits],
+              currency: params[:currency],
               expiration_at: params[:expiration_at],
             }.compact,
           }


### PR DESCRIPTION
This PR allows the `currency` param to be sent for the `Wallet` resource. Otherwise, creating a wallet when the customer has a non-USD currency errors with `currencies_does_not_match`.

