### PR TITLE
fix(credit-note): Item amount whitlisting

### DIFF
--- a/lib/lago/api/resources/credit_note.rb
+++ b/lib/lago/api/resources/credit_note.rb
@@ -29,7 +29,7 @@ module Lago
         def whitelist_items(items)
           items.each_with_object([]) do |item, result|
             filtered_item = (item || {}).slice(
-              :fee_id, :credit_amount_cents, :refund_amount_cents
+              :fee_id, :amount_cents
             )
 
             result << filtered_item unless filtered_item.empty?

--- a/spec/lago/api/resources/credit_note_spec.rb
+++ b/spec/lago/api/resources/credit_note_spec.rb
@@ -33,13 +33,11 @@ RSpec.describe Lago::Api::Resources::CreditNote do
         items: [
           {
             fee_id: 'some-lago-fee-id-1',
-            credit_amount_cents: 10,
-            refund_amount_cents: 5,
+            amount_cents: 10,
           },
           {
             fee_id: 'some-lago-fee-id-2',
-            credit_amount_cents: 5,
-            refund_amount_cents: 10,
+            amount_cents: 5,
           },
         ],
       }


### PR DESCRIPTION
## Context

Credit note item whitelisting is not aligned with the documentation and expectation on Lago API.

API is expecting for an `amount_cents` attribute, while this SDK is whitelisting `credit_amount_cents` and `refund_amount_cents`.

## Description

This PR fixes the implementation by replacing the item attribute whitelisting with `amount_cents`