### PR TITLE
fix(credit-note): Accept credit_amount_cents and refund_amount_cents

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lago-ruby-client (0.34.0.pre.beta)
+    lago-ruby-client (0.34.1.pre.beta)
       jwt
       openssl
 

--- a/lib/lago/api/resources/credit_note.rb
+++ b/lib/lago/api/resources/credit_note.rb
@@ -16,7 +16,9 @@ module Lago
           result_hash = {
             invoice_id: params[:invoice_id],
             reason: params[:reason],
-            refund_status: params[:refund_status]
+            refund_status: params[:refund_status],
+            credit_amount_cents: params[:credit_amount_cents],
+            refund_amount_cents: params[:refund_amount_cents],
           }.compact
 
           whitelist_items(params[:items] || []).tap do |items|

--- a/lib/lago/version.rb
+++ b/lib/lago/version.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
 module Lago
-<<<<<<< Updated upstream
-  VERSION = '0.34.0-beta'
-=======
   VERSION = '0.34.1-beta'
->>>>>>> Stashed changes
 end

--- a/lib/lago/version.rb
+++ b/lib/lago/version.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 module Lago
+<<<<<<< Updated upstream
   VERSION = '0.34.0-beta'
+=======
+  VERSION = '0.34.1-beta'
+>>>>>>> Stashed changes
 end


### PR DESCRIPTION
## Context

Credit note whitelisting is not aligned with the documentation and expectation on Lago API.

API is expecting for a `credit_amount_cents` or `refund_amount_cents` attribute, while this SDK is whitelisting not whitelisting them

## Description

This PR fixes the implementation by adding `credit_amount_cents` and `refund_amount_cents` to the attribute whitelisting