### PR TITLE
feat: add description field to coupons

### DIFF
--- a/lib/lago/api/resources/coupon.rb
+++ b/lib/lago/api/resources/coupon.rb
@@ -16,6 +16,7 @@ module Lago
           result_hash = {
             name: params[:name],
             code: params[:code],
+            description: params[:description],
             amount_cents: params[:amount_cents],
             amount_currency: params[:amount_currency],
             percentage_rate: params[:percentage_rate],

--- a/spec/factories/coupon.rb
+++ b/spec/factories/coupon.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :coupon, class: OpenStruct do
     name { 'coupon_name' }
     code { 'coupon_code' }
+    description { 'coupon_description' }
     expiration_at { '2022-08-08T23:59:59Z' }
     expiration { 'no_expiration' }
     amount_cents { 200 }

--- a/spec/lago/api/resources/coupon_spec.rb
+++ b/spec/lago/api/resources/coupon_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Lago::Api::Resources::Coupon do
         'lago_id' => 'this-is-lago-id',
         'name' => factory_coupon.name,
         'code' => factory_coupon.code,
+        'description' => factory_coupon.description,
         'amount_cents' => factory_coupon.amount_cents,
         'amount_currency' => factory_coupon.amount_currency,
         'expiration' => factory_coupon.expiration,
@@ -54,6 +55,7 @@ RSpec.describe Lago::Api::Resources::Coupon do
 
         expect(coupon.lago_id).to eq('this-is-lago-id')
         expect(coupon.name).to eq(factory_coupon.name)
+        expect(coupon.description).to eq(factory_coupon.description)
         expect(coupon.plan_codes).to eq(factory_coupon.applies_to[:plan_codes])
         expect(coupon.billable_metric_codes).to eq(factory_coupon.applies_to[:billable_metric_codes])
       end


### PR DESCRIPTION
This PR adds the coupon's description attribute now available