### PR TITLE
feat(subscription) allow to pass status to index and delete

### DIFF
--- a/lib/lago/api/connection.rb
+++ b/lib/lago/api/connection.rb
@@ -45,8 +45,10 @@ module Lago
         handle_response(response)
       end
 
-      def destroy(path = uri.path, identifier:)
-        uri_path = "#{path}/#{identifier}"
+      def destroy(path = uri.path, identifier:, options: nil)
+        uri_path = path
+        uri_path += "/#{identifier}" if identifier
+        uri_path += "?#{URI.encode_www_form(options)}" unless options.nil?
         response = http_client.send_request(
           'DELETE',
           uri_path,

--- a/lib/lago/api/resources/base.rb
+++ b/lib/lago/api/resources/base.rb
@@ -42,8 +42,8 @@ module Lago
           JSON.parse(response.to_json, object_class: OpenStruct)
         end
 
-        def destroy(identifier)
-          response = connection.destroy(identifier: identifier)[root_name]
+        def destroy(identifier, options: nil)
+          response = connection.destroy(identifier: identifier, options: options)[root_name]
 
           JSON.parse(response.to_json, object_class: OpenStruct)
         end


### PR DESCRIPTION
This PR adds 2 improvements
1. you can now delete a pending subscription by passing a `status=pending` as query param
2. You can now filter `GET /subscriptions` by passing an array of status as query param 