### PR TITLE
feat(tax): Add taxes to add ons

### DIFF
--- a/lib/lago/api/resources/add_on.rb
+++ b/lib/lago/api/resources/add_on.rb
@@ -19,7 +19,8 @@ module Lago
               code: params[:code],
               description: params[:description],
               amount_cents: params[:amount_cents],
-              amount_currency: params[:amount_currency]
+              amount_currency: params[:amount_currency],
+              tax_codes: params[:tax_codes],
             }.compact
           }
         end

--- a/lib/lago/api/resources/invoice.rb
+++ b/lib/lago/api/resources/invoice.rb
@@ -90,7 +90,7 @@ module Lago
           processed_fees = []
 
           fees.each do |f|
-            result = (f || {}).slice(:add_on_code, :unit_amount_cents, :units, :description)
+            result = (f || {}).slice(:add_on_code, :unit_amount_cents, :units, :description, :tax_codes)
 
             processed_fees << result unless result.empty?
           end

--- a/spec/factories/add_on.rb
+++ b/spec/factories/add_on.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     description { 'test description' }
     amount_cents { 200 }
     amount_currency { 'EUR' }
+    tax_codes { ['tax_code'] }
   end
 end

--- a/spec/factories/tax.rb
+++ b/spec/factories/tax.rb
@@ -2,10 +2,10 @@
 
 FactoryBot.define do
   factory :create_tax, class: OpenStruct do
-    name { 'name_rate' }
-    code { 'code_rate' }
+    name { 'name_tax' }
+    code { 'code_tax' }
     rate { 15.0 }
-    description { 'description_rate' }
+    description { 'description_tax' }
     applied_to_organization { false }
   end
 end

--- a/spec/fixtures/api/customer.json
+++ b/spec/fixtures/api/customer.json
@@ -42,6 +42,7 @@
         "code": "tax_code",
         "rate": 15.0,
         "description": "tax_desc",
+        "add_ons_count": 0,
         "customers_count": 0,
         "plans_count": 0,
         "charges_count": 0,

--- a/spec/fixtures/api/invoice.json
+++ b/spec/fixtures/api/invoice.json
@@ -72,6 +72,7 @@
           "code": "tax_code",
           "rate": 15.0,
           "description": "tax_desc",
+          "add_ons_count": 0,
           "customers_count": 0,
           "plans_count": 0,
           "charges_count": 0,

--- a/spec/fixtures/api/organization.json
+++ b/spec/fixtures/api/organization.json
@@ -29,6 +29,7 @@
         "code": "tax_code",
         "rate": 15.0,
         "description": "tax_desc",
+        "add_ons_count": 0,
         "customers_count": 0,
         "plans_count": 0,
         "charges_count": 0,

--- a/spec/fixtures/api/tax.json
+++ b/spec/fixtures/api/tax.json
@@ -5,6 +5,7 @@
     "code": "tax_code",
     "rate": 15.0,
     "description": "tax_desc",
+    "add_ons_count": 0,
     "customers_count": 0,
     "plans_count": 0,
     "charges_count": 0,

--- a/spec/fixtures/api/taxes.json
+++ b/spec/fixtures/api/taxes.json
@@ -6,6 +6,7 @@
       "code": "tax_code",
       "rate": 15.0,
       "description": "tax_desc",
+      "add_ons_count": 0,
       "customers_count": 0,
       "plans_count": 0,
       "charges_count": 0,

--- a/spec/lago/api/resources/add_on_spec.rb
+++ b/spec/lago/api/resources/add_on_spec.rb
@@ -16,7 +16,21 @@ RSpec.describe Lago::Api::Resources::AddOn do
         'amount_cents' => factory_add_on.amount_cents,
         'amount_currency' => factory_add_on.amount_currency,
         'description' => factory_add_on.description,
-        'created_at' => '2022-04-29T08:59:51Z'
+        'created_at' => '2022-04-29T08:59:51Z',
+        'taxes' => [
+          {
+            'lago_id' => '1a901a90-1a90-1a90-1a90-1a901a901a90',
+            'name' => 'tax_name',
+            'code' => 'tax_code',
+            'rate' => 15.0,
+            'description' => 'tax_desc',
+            'customers_count' => 0,
+            'plans_count' => 0,
+            'charges_count' => 0,
+            'applied_to_organization' => false,
+            'created_at' => '2022-04-29T08:59:51Z'
+          }
+        ]
       }
     }.to_json
   end
@@ -48,6 +62,7 @@ RSpec.describe Lago::Api::Resources::AddOn do
 
         expect(add_on.lago_id).to eq('this-is-lago-id')
         expect(add_on.name).to eq(factory_add_on.name)
+        expect(add_on.taxes.map(&:code)).to eq(['tax_code'])
       end
     end
 

--- a/spec/lago/api/resources/add_on_spec.rb
+++ b/spec/lago/api/resources/add_on_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Lago::Api::Resources::AddOn do
             'code' => 'tax_code',
             'rate' => 15.0,
             'description' => 'tax_desc',
+            'add_ons_count' => 0,
             'customers_count' => 0,
             'plans_count' => 0,
             'charges_count' => 0,

--- a/spec/lago/api/resources/invoice_spec.rb
+++ b/spec/lago/api/resources/invoice_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Lago::Api::Resources::Invoice do
 
   let(:invoice_response) { load_fixture('invoice') }
   let(:invoice_id) { JSON.parse(invoice_response)['invoice']['lago_id'] }
+  let(:tax) { create(:create_tax) }
 
   let(:error_response) do
     {
@@ -28,6 +29,7 @@ RSpec.describe Lago::Api::Resources::Invoice do
           {
             add_on_code: '123',
             description: 'desc',
+            tax_codes: [tax.code],
           }
         ],
       }
@@ -43,11 +45,14 @@ RSpec.describe Lago::Api::Resources::Invoice do
       it 'returns invoice' do
         invoice = resource.create(params)
 
-        expect(invoice.lago_id).to eq(invoice_id)
-        expect(invoice.net_payment_term).to eq(0)
-        expect(invoice.payment_due_date).to eq('2022-06-02')
-        expect(invoice.payment_status).to eq('succeeded')
-        expect(invoice.invoice_type).to eq('one_off')
+        expect(invoice).to have_attributes(
+          lago_id: invoice_id,
+          net_payment_term: 0,
+          payment_due_date: '2022-06-02',
+          payment_status: 'succeeded',
+          invoice_type: 'one_off'
+        )
+        expect(invoice.applied_taxes.first.tax_code).to eq('tax_code')
       end
     end
 


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at add ons level.

## Description

This PR adds the ability to assign taxes on add on create/update.