### PR TITLE
feat(weighted-sum): Add weighted sum fields to billable metric

### DIFF
--- a/lib/lago/api/resources/billable_metric.rb
+++ b/lib/lago/api/resources/billable_metric.rb
@@ -20,6 +20,7 @@ module Lago
               description: params[:description],
               recurring: params[:recurring],
               aggregation_type: params[:aggregation_type],
+              weighted_interval: params[:weighted_interval],
               field_name: params[:field_name],
               group: params[:group],
             }.compact,

--- a/spec/factories/billable_metric.rb
+++ b/spec/factories/billable_metric.rb
@@ -1,10 +1,13 @@
 FactoryBot.define do
-  factory :billable_metric, class: OpenStruct do
+  factory :create_billable_metric, class: OpenStruct do
     name { 'BM1' }
     code { 'BM_code' }
     description { 'description' }
     recurring { false }
     aggregation_type { 'sum_agg' }
     field_name { 'amount_sum' }
+  end
+
+  factory :update_billable_metric, parent: :create_billable_metric do
   end
 end

--- a/spec/fixtures/api/billable_metric.json
+++ b/spec/fixtures/api/billable_metric.json
@@ -1,0 +1,20 @@
+{
+  "billable_metric": {
+    "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
+    "name": "bm_name",
+    "code": "bm_code",
+    "description": "description",
+    "aggregation_type": "sum_agg",
+    "weighted_interval": null,
+    "recurring": false,
+    "field_name": "amount_sum",
+    "created_at": "2022-04-29T08:59:51Z",
+    "group": {
+      "key": "country",
+      "values": ["france", "italy", "spain"]
+    },
+    "active_subscriptions_count": 0,
+    "draft_invoices_count": 0,
+    "plans_count": 0
+  }
+}

--- a/spec/fixtures/api/billable_metric_index.json
+++ b/spec/fixtures/api/billable_metric_index.json
@@ -1,0 +1,41 @@
+{
+  "billable_metrics": [
+    {
+      "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1000",
+      "name": "bm_name",
+      "code": "bm_code",
+      "description": "description",
+      "aggregation_type": "sum_agg",
+      "weighted_interval": null,
+      "recurring": false,
+      "field_name": "amount_sum",
+      "created_at": "2022-04-29T08:59:51Z",
+      "group": {},
+      "active_subscriptions_count": 0,
+      "draft_invoices_count": 0,
+      "plans_count": 0
+    },
+    {
+      "lago_id": "b7ab2926-1de8-4428-9bcd-779314a11111",
+      "name": "bm2_name",
+      "code": "bm2_code",
+      "description": "description2",
+      "aggregation_type": "sum_agg",
+      "weighted_interval": null,
+      "recurring": false,
+      "field_name": "amount_sum",
+      "created_at": "2022-04-30T08:59:51Z",
+      "group": {},
+      "active_subscriptions_count": 0,
+      "draft_invoices_count": 0,
+      "plans_count": 0
+    }
+  ],
+  "meta": {
+    "current_page": 1,
+    "next_page": 2,
+    "prev_page": null,
+    "total_pages": 8,
+    "total_count": 73
+  }
+}

--- a/spec/lago/api/resources/group_spec.rb
+++ b/spec/lago/api/resources/group_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Lago::Api::Resources::Group do
   let(:client) { Lago::Api::Client.new }
   let(:group) { build(:group) }
   let(:lago_id) { 'lago_internal_id' }
-  let(:metric) { build(:billable_metric) }
+  let(:metric) { build(:create_billable_metric) }
 
   let(:not_found_response) do
     {


### PR DESCRIPTION
## Context

For metrics that are charged upon a time frame, Lago is not able to calculate correctly the charge. For instance, imagine you want to price the number of GB/seconds used by a server. Currently, you can either calculate the number of seconds used, or the number of Gigabytes used, but not both at the same time.

## Description

This PR adds:
- the new `Event#timestamp` format with miliseconds precision
- The new `weighted_sum_agg` aggregation value in the `BillableMetric#aggregation_type` enumeation
- The new `BillableMetric#weighted_interval` enum
