### PR TITLE
fix(coupon): Add missing coupons#terminated_at

### DIFF
--- a/lib/lago/api/resources/coupon.rb
+++ b/lib/lago/api/resources/coupon.rb
@@ -26,6 +26,7 @@ module Lago
             frequency_duration: params[:frequency_duration],
             expiration: params[:expiration],
             expiration_at: params[:expiration_at],
+            terminated_at: params[:terminated_at],
           }.compact
 
           whitelist_limitations(params[:applies_to]).tap do |limitations|

--- a/spec/fixtures/api/coupon.json
+++ b/spec/fixtures/api/coupon.json
@@ -1,0 +1,23 @@
+{
+  "coupon": {
+    "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
+    "name": "coupon_name",
+    "code": "coupon_code",
+    "description": "coupon_description",
+    "amount_cents": 5000,
+    "amount_currency": "USD",
+    "expiration": "no_expiration",
+    "expiration_at": "2022-08-08T23:59:59Z",
+    "percentage_rate": null,
+    "frequency": "once",
+    "frequency_duration": null,
+    "coupon_type": "fixed_amount",
+    "reusable": false,
+    "limited_plans": true,
+    "limited_billable_metrics": false,
+    "plan_codes": ["plan1"],
+    "billable_metric_codes": [],
+    "created_at": "2022-04-29T08:59:51Z",
+    "terminated_at": "2022-08-08T23:59:59Z"
+  }
+}


### PR DESCRIPTION
## Context

Call to `GET /v1/api/coupons/:code` is missing the `terminated_at` value

## Description

This PR is adding the missing field in the `V1::CouponSerializer`