### PR TITLE
feat(invoice_display_name): Add invoice display name

### DIFF
--- a/lib/lago/api/resources/add_on.rb
+++ b/lib/lago/api/resources/add_on.rb
@@ -16,6 +16,7 @@ module Lago
           {
             root_name => {
               name: params[:name],
+              invoice_display_name: params[:invoice_display_name],
               code: params[:code],
               description: params[:description],
               amount_cents: params[:amount_cents],

--- a/lib/lago/api/resources/invoice.rb
+++ b/lib/lago/api/resources/invoice.rb
@@ -90,7 +90,14 @@ module Lago
           processed_fees = []
 
           fees.each do |f|
-            result = (f || {}).slice(:add_on_code, :unit_amount_cents, :units, :description, :tax_codes)
+            result = (f || {}).slice(
+              :add_on_code,
+              :unit_amount_cents,
+              :units,
+              :description,
+              :tax_codes,
+              :invoice_display_name,
+            )
 
             processed_fees << result unless result.empty?
           end

--- a/lib/lago/api/resources/plan.rb
+++ b/lib/lago/api/resources/plan.rb
@@ -15,6 +15,7 @@ module Lago
         def whitelist_params(params)
           result_hash = {
             name: params[:name],
+            invoice_display_name: params[:invoice_display_name],
             code: params[:code],
             interval: params[:interval],
             description: params[:description],
@@ -43,6 +44,7 @@ module Lago
               :charge_model,
               :pay_in_advance,
               :invoiceable,
+              :invoice_display_name,
               :min_amount_cents,
               :properties,
               :group_properties,

--- a/spec/factories/add_on.rb
+++ b/spec/factories/add_on.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :add_on, class: OpenStruct do
     name { 'name_add_on' }
+    invoice_display_name { 'invoice_name_add_on' }
     code { 'code_add_on' }
     description { 'test description' }
     amount_cents { 200 }

--- a/spec/factories/plan.rb
+++ b/spec/factories/plan.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :plan, class: OpenStruct do
     name { 'plan1' }
+    invoice_display_name { 'PLN1' }
     code { 'plan_code' }
     interval { 'monthly' }
     description { 'desc' }
@@ -18,6 +19,7 @@ FactoryBot.define do
           charge_model: 'standard',
           pay_in_advance: false,
           invoiceable: true,
+          invoice_display_name: 'Charge 1',
           min_amount_cents: 0,
           properties: { amount: '0.22' },
         },

--- a/spec/fixtures/api/credit_note.json
+++ b/spec/fixtures/api/credit_note.json
@@ -27,7 +27,8 @@
           "item": {
             "type": "charge",
             "code": "seats",
-            "name": "User Seats"
+            "name": "User Seats",
+            "invoice_display_name": "User Seats Invoice"
           },
           "credit_amount_cents": 100,
           "credit_amount_currency": "EUR",

--- a/spec/fixtures/api/fee.json
+++ b/spec/fixtures/api/fee.json
@@ -5,10 +5,12 @@
     "lago_invoice_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
     "lago_true_up_fee_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
     "lago_true_up_parent_fee_id": null,
+    "invoice_display_name": "Fee name",
     "item": {
       "type": "charge",
       "code": "fee_code",
-      "name": "Fee Code"
+      "name": "Fee Code",
+      "invoice_display_name": "Fee C1"
     },
     "amount_cents": 120,
     "amount_currency": "EUR",

--- a/spec/fixtures/api/invoice.json
+++ b/spec/fixtures/api/invoice.json
@@ -105,7 +105,8 @@
         "item": {
           "type": "charge",
           "code": "seats",
-          "name": "User Seats"
+          "name": "User Seats",
+          "invoice_display_name": "User Seats on Invoice"
         },
         "amount_cents": 100,
         "amount_currency": "EUR",

--- a/spec/lago/api/resources/add_on_spec.rb
+++ b/spec/lago/api/resources/add_on_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Lago::Api::Resources::AddOn do
       'add_on' => {
         'lago_id' => 'this-is-lago-id',
         'name' => factory_add_on.name,
+        'invoice_display_name' => factory_add_on.invoice_display_name,
         'code' => factory_add_on.code,
         'amount_cents' => factory_add_on.amount_cents,
         'amount_currency' => factory_add_on.amount_currency,
@@ -63,6 +64,7 @@ RSpec.describe Lago::Api::Resources::AddOn do
 
         expect(add_on.lago_id).to eq('this-is-lago-id')
         expect(add_on.name).to eq(factory_add_on.name)
+        expect(add_on.invoice_display_name).to eq(factory_add_on.invoice_display_name)
         expect(add_on.taxes.map(&:code)).to eq(['tax_code'])
       end
     end
@@ -100,6 +102,7 @@ RSpec.describe Lago::Api::Resources::AddOn do
 
         expect(add_on.lago_id).to eq('this-is-lago-id')
         expect(add_on.name).to eq(factory_add_on.name)
+        expect(add_on.invoice_display_name).to eq(factory_add_on.invoice_display_name)
       end
     end
 
@@ -128,6 +131,7 @@ RSpec.describe Lago::Api::Resources::AddOn do
 
         expect(add_on.lago_id).to eq('this-is-lago-id')
         expect(add_on.name).to eq(factory_add_on.name)
+        expect(add_on.invoice_display_name).to eq(factory_add_on.invoice_display_name)
       end
     end
 
@@ -155,6 +159,7 @@ RSpec.describe Lago::Api::Resources::AddOn do
 
         expect(add_on.lago_id).to eq('this-is-lago-id')
         expect(add_on.name).to eq(factory_add_on.name)
+        expect(add_on.invoice_display_name).to eq(factory_add_on.invoice_display_name)
       end
     end
 
@@ -177,6 +182,7 @@ RSpec.describe Lago::Api::Resources::AddOn do
           {
             'lago_id' => 'this-is-lago-id',
             'name' => factory_add_on.name,
+            'invoice_display_name' => factory_add_on.invoice_display_name,
             'code' => factory_add_on.code,
             'amount_cents' => factory_add_on.amount_cents,
             'amount_currency' => factory_add_on.amount_currency,
@@ -205,6 +211,7 @@ RSpec.describe Lago::Api::Resources::AddOn do
 
         expect(response['add_ons'].first['lago_id']).to eq('this-is-lago-id')
         expect(response['add_ons'].first['name']).to eq(factory_add_on.name)
+        expect(response['add_ons'].first['invoice_display_name']).to eq(factory_add_on.invoice_display_name)
         expect(response['meta']['current_page']).to eq(1)
       end
     end
@@ -220,6 +227,7 @@ RSpec.describe Lago::Api::Resources::AddOn do
 
         expect(response['add_ons'].first['lago_id']).to eq('this-is-lago-id')
         expect(response['add_ons'].first['name']).to eq(factory_add_on.name)
+        expect(response['add_ons'].first['invoice_display_name']).to eq(factory_add_on.invoice_display_name)
         expect(response['meta']['current_page']).to eq(1)
       end
     end

--- a/spec/lago/api/resources/fee_spec.rb
+++ b/spec/lago/api/resources/fee_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe Lago::Api::Resources::Fee do
   let(:client) { Lago::Api::Client.new }
 
   let(:fee_response) { load_fixture('fee') }
-  let(:fee_id) { JSON.parse(fee_response)['fee']['lago_id'] }
+  let(:fee_json) { JSON.parse(fee_response)['fee'] }
+  let(:fee_id) { fee_json['lago_id'] }
+  let(:fee_invoice_display_name) { fee_json['invoice_display_name'] }
 
   let(:error_response) do
     {
@@ -29,6 +31,7 @@ RSpec.describe Lago::Api::Resources::Fee do
         fee = resource.get(fee_id)
 
         expect(fee.lago_id).to eq(fee_id)
+        expect(fee.invoice_display_name).to eq(fee_invoice_display_name)
       end
     end
 
@@ -68,6 +71,7 @@ RSpec.describe Lago::Api::Resources::Fee do
         response = resource.get_all
 
         expect(response['fees'].first['lago_id']).to eq(fee_id)
+        expect(response['fees'].first['invoice_display_name']).to eq(fee_invoice_display_name)
       end
 
       context 'when filters are present' do

--- a/spec/lago/api/resources/plan_spec.rb
+++ b/spec/lago/api/resources/plan_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Lago::Api::Resources::Plan do
       'plan' => {
         'lago_id' => 'this-is-lago-id',
         'name' => factory_plan.name,
+        'invoice_display_name' => factory_plan.invoice_display_name,
         'created_at' => '2022-04-29T08:59:51Z',
         'code' => factory_plan.code,
         'interval' => factory_plan.amount_cents,
@@ -67,6 +68,7 @@ RSpec.describe Lago::Api::Resources::Plan do
 
         expect(plan.lago_id).to eq('this-is-lago-id')
         expect(plan.name).to eq(factory_plan.name)
+        expect(plan.invoice_display_name).to eq(factory_plan.invoice_display_name)
         expect(plan.taxes.map(&:code)).to eq(tax_codes)
       end
     end
@@ -104,6 +106,7 @@ RSpec.describe Lago::Api::Resources::Plan do
 
         expect(plan.lago_id).to eq('this-is-lago-id')
         expect(plan.name).to eq(factory_plan.name)
+        expect(plan.invoice_display_name).to eq(factory_plan.invoice_display_name)
       end
     end
 
@@ -132,6 +135,7 @@ RSpec.describe Lago::Api::Resources::Plan do
 
         expect(plan.lago_id).to eq('this-is-lago-id')
         expect(plan.name).to eq(factory_plan.name)
+        expect(plan.invoice_display_name).to eq(factory_plan.invoice_display_name)
       end
     end
 
@@ -159,6 +163,7 @@ RSpec.describe Lago::Api::Resources::Plan do
 
         expect(plan.lago_id).to eq('this-is-lago-id')
         expect(plan.name).to eq(factory_plan.name)
+        expect(plan.invoice_display_name).to eq(factory_plan.invoice_display_name)
       end
     end
 
@@ -181,6 +186,7 @@ RSpec.describe Lago::Api::Resources::Plan do
           {
             'lago_id' => 'this-is-lago-id',
             'name' => factory_plan.name,
+            'invoice_display_name' => factory_plan.invoice_display_name,
             'created_at' => '2022-04-29T08:59:51Z',
             'code' => factory_plan.code,
             'interval' => factory_plan.amount_cents,
@@ -199,6 +205,7 @@ RSpec.describe Lago::Api::Resources::Plan do
                 'billable_metric_code' => 'bm_code',
                 'created_at' => '2022-04-29T08:59:51Z',
                 'charge_model' => factory_plan.charges.first[:charge_model],
+                'invoice_display_name' => factory_plan.charges.first[:invoice_display_name],
                 'pay_in_advance' => false,
                 'min_amount_cents' => 0,
                 'properties' => factory_plan.charges.first[:properties],
@@ -228,6 +235,8 @@ RSpec.describe Lago::Api::Resources::Plan do
 
         expect(response['plans'].first['lago_id']).to eq('this-is-lago-id')
         expect(response['plans'].first['name']).to eq(factory_plan.name)
+        expect(response['plans'].first['invoice_display_name']).to eq(factory_plan.invoice_display_name)
+        expect(response['plans'].first['charges'].first['invoice_display_name']).to eq(factory_plan.charges.first[:invoice_display_name])
         expect(response['meta']['current_page']).to eq(1)
       end
     end
@@ -243,6 +252,7 @@ RSpec.describe Lago::Api::Resources::Plan do
 
         expect(response['plans'].first['lago_id']).to eq('this-is-lago-id')
         expect(response['plans'].first['name']).to eq(factory_plan.name)
+        expect(response['plans'].first['invoice_display_name']).to eq(factory_plan.invoice_display_name)
         expect(response['meta']['current_page']).to eq(1)
       end
     end


### PR DESCRIPTION
## Context

Add a custom name to display on invoice for subscription fee and charges

## Description

When generating an invoice, don't display the name of the plan or the name of the billable metrics to the customer.