### PR TITLE
feat(past_usage): Expose route to fetch customer past usage

### DIFF
--- a/lib/lago/api/resources/customer.rb
+++ b/lib/lago/api/resources/customer.rb
@@ -14,14 +14,26 @@ module Lago
 
         def current_usage(external_customer_id, external_subscription_id)
           uri = URI(
-            "#{client.base_api_url}#{api_resource}/#{external_customer_id}/current_usage?external_subscription_id=#{external_subscription_id}"
+            "#{client.base_api_url}#{api_resource}/#{external_customer_id}" \
+              "/current_usage?external_subscription_id=#{external_subscription_id}",
           )
           connection.get(uri, identifier: nil)
         end
 
+        def past_usage(external_customer_id, external_subscription_id, options = {})
+          uri = URI(
+            "#{client.base_api_url}#{api_resource}/#{external_customer_id}/past_usage",
+          )
+
+          connection.get_all(
+            options.merge(external_subscription_id: external_subscription_id),
+            uri,
+          )
+        end
+
         def portal_url(external_customer_id)
           uri = URI(
-            "#{client.base_api_url}#{api_resource}/#{external_customer_id}/portal_url"
+            "#{client.base_api_url}#{api_resource}/#{external_customer_id}/portal_url",
           )
 
           response = connection.get(uri, identifier: nil)[root_name]

--- a/spec/fixtures/api/customer_past_usage.json
+++ b/spec/fixtures/api/customer_past_usage.json
@@ -1,0 +1,39 @@
+{
+  "usage_periods": [
+    {
+      "from_datetime": "2022-07-01T00:00:00Z",
+      "to_datetime": "2022-07-31T23:59:59Z",
+      "issuing_date": "2022-08-01",
+      "lago_invoice_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+      "currency": "EUR",
+      "amount_cents": 123,
+      "total_amount_cents": 123,
+      "taxes_amount_cents": 0,
+      "charges_usage": [
+        {
+          "units": "1.0",
+          "events_count": 1,
+          "amount_cents": 123,
+          "amount_currency": "EUR",
+          "charge": {
+            "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+            "charge_model": "graduated"
+          },
+          "billable_metric": {
+            "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+            "name": "Usage metric",
+            "code": "usage_metric",
+            "aggregation_type": "sum"
+          }
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "current_page": 1,
+    "next_page": 2,
+    "prev_page": null,
+    "total_pages": 2,
+    "total_count": 49
+  }
+}

--- a/spec/fixtures/api/customer_usage.json
+++ b/spec/fixtures/api/customer_usage.json
@@ -3,6 +3,7 @@
     "from_datetime": "2022-07-01T00:00:00Z",
     "to_datetime": "2022-07-31T23:59:59Z",
     "issuing_date": "2022-08-01",
+    "lago_invoice_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
     "currency": "EUR",
     "amount_cents": 123,
     "total_amount_cents": 123,
@@ -10,6 +11,7 @@
     "charges_usage": [
       {
         "units": "1.0",
+        "events_count": 1,
         "amount_cents": 123,
         "amount_currency": "EUR",
         "charge": {


### PR DESCRIPTION
## Context

Some of our users want to retrieve usage in the past. The main problem they are facing is that at the beginning of a new period, they cannot compute usage in third party systems, or see if everything went well as usage for the past period has been removed.

## Description

This PR adds a new route to fetch the past_usage for a customer/subscription.
