### PR TITLE
fix(encoding): Fix identifier encoding

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lago-ruby-client (0.51.0.pre.beta)
+    lago-ruby-client (0.52.1.pre.beta)
       jwt
       openssl
 

--- a/lib/lago/api/connection.rb
+++ b/lib/lago/api/connection.rb
@@ -34,7 +34,7 @@ module Lago
       end
 
       def get(path = uri.path, identifier:)
-        uri_path = identifier.nil? ? path : "#{path}/#{identifier}"
+        uri_path = identifier.nil? ? path : "#{path}/#{URI.encode_www_form_component(identifier)}"
         response = http_client.send_request(
           'GET',
           uri_path,

--- a/spec/lago/api/connection_spec.rb
+++ b/spec/lago/api/connection_spec.rb
@@ -6,9 +6,11 @@ RSpec.describe Lago::Api::Connection do
   subject(:connection) do
     described_class.new(
       'fake-api-key',
-      URI('https://testapi.example.org/')
+      uri
     )
   end
+
+  let(:uri) { URI('https://testapi.example.org') }
 
   context 'when an unsuccessful request is made' do
     before do
@@ -21,6 +23,24 @@ RSpec.describe Lago::Api::Connection do
         expect(exception).to be_a(Lago::Api::HttpError)
         expect(exception.error_code).to eq 404
       }
+    end
+  end
+
+  describe '#get' do
+    let(:identifier) { 'gid://app/Customer/1234' }
+
+    before do
+      stub_request(:get, 'https://testapi.example.org:443/gid:%2F%2Fapp%2FCustomer%2F1234')
+
+      allow(URI).to receive(:encode_www_form_component)
+        .with(identifier)
+        .and_return('gid:%2F%2Fapp%2FCustomer%2F1234')
+
+      connection.get(identifier: identifier)
+    end
+
+    it 'encodes the identifier' do
+      expect(URI).to have_received(:encode_www_form_component).with(identifier)
     end
   end
 end


### PR DESCRIPTION
This PR fixes a [bug](https://github.com/getlago/lago-ruby-client/issues/136#event-11026146821).
Identifier in the url is not encoded properly.
