### PR TITLE
feat (document-numbering): Add support for new document numbering fields

### DIFF
--- a/lib/lago/api/resources/organization.rb
+++ b/lib/lago/api/resources/organization.rb
@@ -30,6 +30,8 @@ module Lago
             tax_identification_number: params[:tax_identification_number],
             timezone: params[:timezone],
             email_settings: params[:email_settings],
+            document_numbering: params[:document_numbering],
+            document_number_prefix: params[:document_number_prefix],
           }.compact
 
           whitelist_billing_configuration(params[:billing_configuration]).tap do |config|

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -16,6 +16,8 @@ FactoryBot.define do
     legal_number { 'legal2' }
     net_payment_term { 0 }
     tax_identification_number { 'EU123456789' }
+    document_numbering { 1 }
+    document_number_prefix { 'ORG-1234' }
     billing_configuration do
       {
         invoice_footer: 'footer',

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     legal_number { 'legal2' }
     net_payment_term { 0 }
     tax_identification_number { 'EU123456789' }
-    document_numbering { 1 }
+    document_numbering { 'per_customer' }
     document_number_prefix { 'ORG-1234' }
     billing_configuration do
       {

--- a/spec/fixtures/api/organization.json
+++ b/spec/fixtures/api/organization.json
@@ -17,7 +17,7 @@
     "net_payment_term": 0,
     "tax_identification_number": "EU123456789",
     "timezone": "America/New_York",
-    "document_numbering": 1,
+    "document_numbering": "per_customer",
     "document_number_prefix": "ORG-1234",
     "billing_configuration": {
       "invoice_footer": null,

--- a/spec/fixtures/api/organization.json
+++ b/spec/fixtures/api/organization.json
@@ -17,6 +17,8 @@
     "net_payment_term": 0,
     "tax_identification_number": "EU123456789",
     "timezone": "America/New_York",
+    "document_numbering": 1,
+    "document_number_prefix": "ORG-1234",
     "billing_configuration": {
       "invoice_footer": null,
       "invoice_grace_period": 3,

--- a/spec/lago/api/resources/organization_spec.rb
+++ b/spec/lago/api/resources/organization_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Lago::Api::Resources::Organization do
         expect(organization.webhook_url).to eq('https://test-example.example')
         expect(organization.webhook_urls).to eq(['https://test-example.example'])
         expect(organization.net_payment_term).to eq(0)
-        expect(organization.document_numbering).to eq(1)
+        expect(organization.document_numbering).to eq('per_customer')
         expect(organization.document_number_prefix).to eq('ORG-1234')
         expect(organization.tax_identification_number).to eq('EU123456789')
         expect(organization.billing_configuration.invoice_grace_period).to eq(3)

--- a/spec/lago/api/resources/organization_spec.rb
+++ b/spec/lago/api/resources/organization_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe Lago::Api::Resources::Organization do
         expect(organization.webhook_url).to eq('https://test-example.example')
         expect(organization.webhook_urls).to eq(['https://test-example.example'])
         expect(organization.net_payment_term).to eq(0)
+        expect(organization.document_numbering).to eq(1)
+        expect(organization.document_number_prefix).to eq('ORG-1234')
         expect(organization.tax_identification_number).to eq('EU123456789')
         expect(organization.billing_configuration.invoice_grace_period).to eq(3)
       end


### PR DESCRIPTION
## Context

Before, it was not possible to adapt document number. With this feature it will be enabled to switch between `per_customer` and `per_organization` document numbering logic. Also, it will be possible to edit number prefix.

## Description

This PR adds support for new document numbering fields