### PR TITLE
feat(grouped-by): Add new fields

### DIFF
--- a/spec/factories/plan.rb
+++ b/spec/factories/plan.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :plan, class: OpenStruct do
+  factory :create_plan, class: OpenStruct do
     name { 'plan1' }
     invoice_display_name { 'PLN1' }
     code { 'plan_code' }

--- a/spec/fixtures/api/fee.json
+++ b/spec/fixtures/api/fee.json
@@ -11,7 +11,10 @@
       "code": "fee_code",
       "name": "Fee Code",
       "invoice_display_name": "Fee C1",
-      "group_invoice_display_name": "Transactions - ACH"
+      "group_invoice_display_name": "Transactions - ACH",
+      "grouped_by": {
+        "agent_name": "aragorn"
+      }
     },
     "amount_cents": 120,
     "amount_currency": "EUR",

--- a/spec/fixtures/api/plan.json
+++ b/spec/fixtures/api/plan.json
@@ -1,0 +1,41 @@
+{
+  "plan": {
+    "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+    "name": "plan1",
+    "invoice_display_name": "PLN1",
+    "created_at": "2022-04-29T08:59:51Z",
+    "code": "plan_code",
+    "interval": "monthly",
+    "description": "desc",
+    "amount_cents": 100,
+    "amount_currency": "EUR",
+    "trial_period": 2,
+    "pay_in_advance": false,
+    "bill_charges_monthly": false,
+    "active_subscriptions_count": 0,
+    "draft_invoices_count": 0,
+    "charges": [
+      {
+        "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+        "lago_billable_metric_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+        "billable_metric_code": "bm_code",
+        "created_at": "2022-04-29T08:59:51Z",
+        "charge_model": "standard",
+        "pay_in_advance": false,
+        "invoiceable": true,
+        "min_amount_cents": 0,
+        "properties": {
+          "amount": "0.22",
+          "grouped_by": [
+            "agent_name"
+          ]
+        }
+      }
+    ],
+    "taxes": [
+      {
+        "code": "tax_code"
+      }
+    ]
+  }
+}

--- a/spec/fixtures/api/plans.json
+++ b/spec/fixtures/api/plans.json
@@ -1,0 +1,51 @@
+{
+  "plans": [
+    {
+      "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+      "name": "plan1",
+      "invoice_display_name": "PLN1",
+      "created_at": "2022-04-29T08:59:51Z",
+      "code": "plan_code",
+      "interval": "monthly",
+      "description": "desc",
+      "amount_cents": 100,
+      "amount_currency": "EUR",
+      "trial_period": 2,
+      "pay_in_advance": false,
+      "bill_charges_monthly": false,
+      "active_subscriptions_count": 0,
+      "draft_invoices_count": 0,
+      "charges": [
+        {
+          "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+          "lago_billable_metric_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+          "billable_metric_code": "bm_code",
+          "created_at": "2022-04-29T08:59:51Z",
+          "charge_model": "standard",
+          "invoice_display_name": "Charge 1",
+          "pay_in_advance": false,
+          "invoiceable": true,
+          "min_amount_cents": 0,
+          "properties": {
+            "amount": "0.22",
+            "grouped_by": [
+              "agent_name"
+            ]
+          }
+        }
+      ],
+      "taxes": [
+        {
+          "code": "tax_code"
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "current_page": 1,
+    "next_page": 2,
+    "prev_page": null,
+    "total_pages": 7,
+    "total_count": 63
+  }
+}


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR adds all the new fields related to the feature
