### PR TITLE
feat(filter): Add filter fields

### DIFF
--- a/lib/lago/api/resources/billable_metric.rb
+++ b/lib/lago/api/resources/billable_metric.rb
@@ -23,6 +23,7 @@ module Lago
               weighted_interval: params[:weighted_interval],
               field_name: params[:field_name],
               group: params[:group],
+              filters: params[:filters],
             }.compact,
           }
         end

--- a/lib/lago/api/resources/plan.rb
+++ b/lib/lago/api/resources/plan.rb
@@ -60,6 +60,7 @@ module Lago
               :min_amount_cents,
               :properties,
               :group_properties,
+              :filters,
               :tax_codes,
             )
 

--- a/spec/fixtures/api/billable_metric.json
+++ b/spec/fixtures/api/billable_metric.json
@@ -11,8 +11,22 @@
     "created_at": "2022-04-29T08:59:51Z",
     "group": {
       "key": "country",
-      "values": ["france", "italy", "spain"]
+      "values": [
+        "france",
+        "italy",
+        "spain"
+      ]
     },
+    "filters": [
+      {
+        "key": "country",
+        "values": [
+          "france",
+          "italy",
+          "spain"
+        ]
+      }
+    ],
     "active_subscriptions_count": 0,
     "draft_invoices_count": 0,
     "plans_count": 0

--- a/spec/fixtures/api/billable_metric_index.json
+++ b/spec/fixtures/api/billable_metric_index.json
@@ -11,6 +11,7 @@
       "field_name": "amount_sum",
       "created_at": "2022-04-29T08:59:51Z",
       "group": {},
+      "filters": [],
       "active_subscriptions_count": 0,
       "draft_invoices_count": 0,
       "plans_count": 0
@@ -26,6 +27,7 @@
       "field_name": "amount_sum",
       "created_at": "2022-04-30T08:59:51Z",
       "group": {},
+      "filters": [],
       "active_subscriptions_count": 0,
       "draft_invoices_count": 0,
       "plans_count": 0

--- a/spec/fixtures/api/customer_past_usage.json
+++ b/spec/fixtures/api/customer_past_usage.json
@@ -24,7 +24,20 @@
             "name": "Usage metric",
             "code": "usage_metric",
             "aggregation_type": "sum"
-          }
+          },
+          "groups": [],
+          "filters": [
+            {
+              "units": "3.0",
+              "events_count": 1,
+              "amount_cents": 123,
+              "values": {
+                "country": [
+                  "france"
+                ]
+              }
+            }
+          ]
         }
       ]
     }

--- a/spec/fixtures/api/customer_usage.json
+++ b/spec/fixtures/api/customer_usage.json
@@ -3,7 +3,7 @@
     "from_datetime": "2022-07-01T00:00:00Z",
     "to_datetime": "2022-07-31T23:59:59Z",
     "issuing_date": "2022-08-01",
-    "lago_invoice_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+    "invoice_id": null,
     "currency": "EUR",
     "amount_cents": 123,
     "total_amount_cents": 123,
@@ -15,16 +15,70 @@
         "amount_cents": 123,
         "amount_currency": "EUR",
         "charge": {
-          "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+          "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
           "charge_model": "graduated",
-          "invoice_display_name": "Setup"
+          "invoice_display_name": "add_on_invoice_display_name"
         },
         "billable_metric": {
-          "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+          "lago_id": "99a6094e-199b-4101-896a-54e927ce7bd7",
           "name": "Usage metric",
           "code": "usage_metric",
           "aggregation_type": "sum"
-        }
+        },
+        "groups": [
+          {
+            "lago_id": "12435687-1de8-4428-9bcd-779314ac1111",
+            "key": "google",
+            "value": "europe",
+            "units": "3.0",
+            "events_count": 1,
+            "amount_cents": 123
+          }
+        ],
+        "filters": [
+          {
+            "units": "3.0",
+            "events_count": 1,
+            "amount_cents": 123,
+            "values": {
+              "country": [
+                "france"
+              ]
+            }
+          }
+        ],
+        "grouped_usage": [
+          {
+            "amount_cents": 123,
+            "events_count": 1,
+            "units": "3.0",
+            "grouped_by": {
+              "agent_name": "aragorn"
+            },
+            "groups": [
+              {
+                "lago_id": "12435687-1de8-4428-9bcd-779314ac1111",
+                "key": "google",
+                "value": "europe",
+                "units": "3.0",
+                "events_count": 1,
+                "amount_cents": 123
+              }
+            ],
+            "filters": [
+              {
+                "units": "3.0",
+                "events_count": 1,
+                "amount_cents": 123,
+                "values": {
+                  "country": [
+                    "france"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/spec/fixtures/api/fee.json
+++ b/spec/fixtures/api/fee.json
@@ -1,17 +1,18 @@
 {
   "fee": {
-    "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
-    "lago_group_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
-    "lago_invoice_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
-    "lago_true_up_fee_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+    "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "lago_group_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
+    "lago_charge_filter_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
+    "lago_invoice_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
+    "lago_true_up_fee_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
     "lago_true_up_parent_fee_id": null,
-    "invoice_display_name": "Fee name",
+    "invoice_display_name": "fee_invoice_display_name",
     "item": {
       "type": "charge",
       "code": "fee_code",
       "name": "Fee Code",
-      "invoice_display_name": "Fee C1",
-      "group_invoice_display_name": "Transactions - ACH",
+      "invoice_display_name": "charge_invoice_display_name",
+      "charge_filter_invoice_display_name": "charge_filter_invoice_display_name",
       "grouped_by": {
         "agent_name": "aragorn"
       }
@@ -23,9 +24,7 @@
     "total_amount_cents": 140,
     "total_amount_currency": "EUR",
     "units": "10.0",
-    "precise_unit_amount": "14.0",
     "events_count": 10,
-    "amount_details": {},
     "applied_taxes": [
       {
         "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",

--- a/spec/fixtures/api/plan.json
+++ b/spec/fixtures/api/plan.json
@@ -1,35 +1,66 @@
 {
   "plan": {
-    "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
-    "name": "plan1",
-    "invoice_display_name": "PLN1",
-    "created_at": "2022-04-29T08:59:51Z",
+    "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1111",
+    "name": "test1",
+    "invoice_display_name": "test plan 1",
+    "created_at": "2022-07-01T14:47:14Z",
     "code": "plan_code",
-    "interval": "monthly",
-    "description": "desc",
-    "amount_cents": 100,
+    "interval": "weekly",
+    "description": "hello_this_is_desc333",
+    "amount_cents": 900,
     "amount_currency": "EUR",
-    "trial_period": 2,
-    "pay_in_advance": false,
-    "bill_charges_monthly": false,
+    "trial_period": 3.0,
+    "pay_in_advance": true,
+    "bill_charges_monthly": null,
     "active_subscriptions_count": 0,
     "draft_invoices_count": 0,
     "charges": [
       {
-        "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
-        "lago_billable_metric_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+        "lago_id": "51c1e851-5be6-4343-a0ee-39a81d8b4ee1",
+        "lago_billable_metric_id": "a6947936-628f-4945-8857-db6858ee7941",
         "billable_metric_code": "bm_code",
-        "created_at": "2022-04-29T08:59:51Z",
+        "created_at": "2022-07-01T14:47:14Z",
+        "amount_currency": "EUR",
+        "prorated": false,
         "charge_model": "standard",
-        "pay_in_advance": false,
+        "pay_in_advance": true,
         "invoiceable": true,
+        "invoice_display_name": "Setup",
         "min_amount_cents": 0,
         "properties": {
           "amount": "0.22",
           "grouped_by": [
             "agent_name"
           ]
-        }
+        },
+        "filters": [
+          {
+            "invoice_display_name": "From France",
+            "properties": {
+              "amount": "0.33"
+            },
+            "values": {
+              "country": [
+                "France"
+              ]
+            }
+          }
+        ],
+        "taxes": [
+          {
+            "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
+            "name": "tax_name",
+            "code": "tax_code",
+            "rate": 15.0,
+            "description": "tax_desc",
+            "add_ons_count": 0,
+            "customers_count": 0,
+            "plans_count": 0,
+            "charges_count": 0,
+            "applied_to_organization": false,
+            "created_at": "2022-04-29T08:59:51Z"
+          }
+        ]
       }
     ],
     "minimum_commitment": {
@@ -48,7 +79,17 @@
     },
     "taxes": [
       {
-        "code": "tax_code"
+        "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
+        "name": "tax_name",
+        "code": "tax_code",
+        "rate": 15.0,
+        "description": "tax_desc",
+        "add_ons_count": 0,
+        "customers_count": 0,
+        "plans_count": 0,
+        "charges_count": 0,
+        "applied_to_organization": false,
+        "created_at": "2022-04-29T08:59:51Z"
       }
     ]
   }

--- a/spec/fixtures/api/plans.json
+++ b/spec/fixtures/api/plans.json
@@ -1,37 +1,60 @@
 {
   "plans": [
     {
-      "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
-      "name": "plan1",
-      "invoice_display_name": "PLN1",
-      "created_at": "2022-04-29T08:59:51Z",
-      "code": "plan_code",
-      "interval": "monthly",
-      "description": "desc",
-      "amount_cents": 100,
+      "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1111",
+      "name": "test1",
+      "invoice_display_name": "test plan 1",
+      "created_at": "2022-07-01T14:47:14Z",
+      "code": "plan_api4",
+      "interval": "weekly",
+      "description": "hello_this_is_desc333",
+      "amount_cents": 900,
       "amount_currency": "EUR",
-      "trial_period": 2,
-      "pay_in_advance": false,
-      "bill_charges_monthly": false,
+      "trial_period": 3.0,
+      "pay_in_advance": true,
+      "bill_charges_monthly": null,
       "active_subscriptions_count": 0,
       "draft_invoices_count": 0,
       "charges": [
         {
-          "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
-          "lago_billable_metric_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+          "lago_id": "51c1e851-5be6-4343-a0ee-39a81d8b4ee1",
+          "lago_billable_metric_id": "a6947936-628f-4945-8857-db6858ee7941",
           "billable_metric_code": "bm_code",
-          "created_at": "2022-04-29T08:59:51Z",
+          "created_at": "2022-07-01T14:47:14Z",
+          "amount_currency": "EUR",
+          "prorated": false,
           "charge_model": "standard",
-          "invoice_display_name": "Charge 1",
-          "pay_in_advance": false,
+          "pay_in_advance": true,
           "invoiceable": true,
-          "min_amount_cents": 0,
+          "invoice_display_name": "Charge 1",
           "properties": {
             "amount": "0.22",
             "grouped_by": [
               "agent_name"
             ]
-          }
+          },
+          "group_properties": [
+            {
+              "group_id": "gfc1e851-5be6-4343-a0ee-39a81d8b4ee1",
+              "values": {
+                "amount": "0.22"
+              },
+              "invoice_display_name": "Europe"
+            }
+          ],
+          "filters": [
+            {
+              "invoice_display_name": "From France",
+              "properties": {
+                "amount": "0.33"
+              },
+              "values": {
+                "country": [
+                  "France"
+                ]
+              }
+            }
+          ]
         }
       ],
       "minimum_commitment": {
@@ -53,13 +76,60 @@
           "code": "tax_code"
         }
       ]
+    },
+    {
+      "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1222",
+      "name": "test2",
+      "created_at": "2022-07-01T12:45:33Z",
+      "code": "plan_api2",
+      "interval": "weekly",
+      "description": "hello_this_is_desc222",
+      "amount_cents": 700,
+      "amount_currency": "EUR",
+      "trial_period": 2.0,
+      "pay_in_advance": true,
+      "bill_charges_monthly": null,
+      "active_subscriptions_count": 0,
+      "draft_invoices_count": 0,
+      "charges": [
+        {
+          "lago_id": "dfdc725d-6341-4d61-831e-4ac9ccd509c0",
+          "lago_billable_metric_id": "a6947936-628f-4945-8857-db6858ee7941",
+          "billable_metric_code": "bm_code",
+          "created_at": "2022-07-01T12:45:33Z",
+          "amount_currency": "EUR",
+          "charge_model": "standard",
+          "prorated": false,
+          "pay_in_advance": true,
+          "invoiceable": true,
+          "properties": {
+            "amount": "0.7"
+          }
+        }
+      ]
+    },
+    {
+      "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1333",
+      "name": "test3",
+      "created_at": "2022-06-23T07:52:26Z",
+      "code": "nj_",
+      "interval": "weekly",
+      "description": "",
+      "amount_cents": 10000,
+      "amount_currency": "USD",
+      "trial_period": 0.0,
+      "pay_in_advance": true,
+      "bill_charges_monthly": null,
+      "active_subscriptions_count": 0,
+      "draft_invoices_count": 0,
+      "charges": []
     }
   ],
   "meta": {
     "current_page": 1,
     "next_page": 2,
     "prev_page": null,
-    "total_pages": 7,
-    "total_count": 63
+    "total_pages": 3,
+    "total_count": 27
   }
 }


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR is related to https://github.com/getlago/lago-openapi/pull/210
It adds the new filter fields in both input and output objects