### PR TITLE
feat(minimum-commitment): Add minimum commitment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lago-ruby-client (0.56.0.pre.beta)
+    lago-ruby-client (1.0.0)
       jwt
       openssl
 

--- a/lib/lago/api/resources/plan.rb
+++ b/lib/lago/api/resources/plan.rb
@@ -31,7 +31,19 @@ module Lago
             result_hash[:charges] = charges unless charges.empty?
           end
 
+          whitelist_minimum_commitment(params[:minimum_commitment]).tap do |minimum_commitment|
+            result_hash[:minimum_commitment] = minimum_commitment
+          end
+
           { root_name => result_hash }
+        end
+
+        def whitelist_minimum_commitment(minimum_commitment)
+          minimum_commitment.slice(
+            :amount_cents,
+            :invoice_display_name,
+            :tax_codes,
+          )
         end
 
         def whitelist_charges(charges)

--- a/spec/factories/minimum_commitment.rb
+++ b/spec/factories/minimum_commitment.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :minimum_commitment, class: OpenStruct do
+    invoice_display_name { 'Minimum commitment (C1)' }
+    plan_code { 'plan_code' }
+    interval { 'monthly' }
+    amount_cents { 200 }
+  end
+end

--- a/spec/factories/plan.rb
+++ b/spec/factories/plan.rb
@@ -25,5 +25,11 @@ FactoryBot.define do
         },
       ]
     end
+    minimum_commitment do
+      {
+        invoice_display_name: 'Minimum commitment (C1)',
+        amount_cents: 100,
+      }
+    end
   end
 end

--- a/spec/fixtures/api/plan.json
+++ b/spec/fixtures/api/plan.json
@@ -32,6 +32,20 @@
         }
       }
     ],
+    "minimum_commitment": {
+      "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+      "plan_code": "plan_code",
+      "invoice_display_name": "Minimum commitment (C1)",
+      "amount_cents": 200,
+      "interval": "monthly",
+      "created_at": "2022-04-29T08:59:51Z",
+      "updated_at": "2022-04-29T08:59:51Z",
+      "taxes": [
+        {
+          "code": "tax_code"
+        }
+      ]
+    },
     "taxes": [
       {
         "code": "tax_code"

--- a/spec/fixtures/api/plans.json
+++ b/spec/fixtures/api/plans.json
@@ -34,6 +34,20 @@
           }
         }
       ],
+      "minimum_commitment": {
+        "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+        "plan_code": "plan_code",
+        "invoice_display_name": "Minimum commitment (C1)",
+        "amount_cents": 200,
+        "interval": "monthly",
+        "created_at": "2022-04-29T08:59:51Z",
+        "updated_at": "2022-04-29T08:59:51Z",
+        "taxes": [
+          {
+            "code": "tax_code"
+          }
+        ]
+      },
       "taxes": [
         {
           "code": "tax_code"

--- a/spec/lago/api/resources/plan_spec.rb
+++ b/spec/lago/api/resources/plan_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Lago::Api::Resources::Plan do
 
   describe '#create' do
     let(:tax_codes) { ['tax_code'] }
+    let(:minimum_commitment) { create(:minimum_commitment) }
     let(:params) { create(:create_plan).to_h.merge(tax_codes: tax_codes) }
     let(:body) do
       { 'plan' => params }
@@ -43,6 +44,9 @@ RSpec.describe Lago::Api::Resources::Plan do
         expect(plan.name).to eq(plan_name)
         expect(plan.invoice_display_name).to eq(plan_dsplay_name)
         expect(plan.taxes.map(&:code)).to eq(tax_codes)
+
+        expect(plan.minimum_commitment.invoice_display_name).to eq(minimum_commitment.invoice_display_name)
+        expect(plan.minimum_commitment.taxes.map(&:code)).to eq(tax_codes)
       end
     end
 
@@ -75,6 +79,7 @@ RSpec.describe Lago::Api::Resources::Plan do
         expect(plan.lago_id).to eq(plan_id)
         expect(plan.name).to eq(plan_name)
         expect(plan.invoice_display_name).to eq(plan_dsplay_name)
+        expect(plan.minimum_commitment.invoice_display_name).to eq('Minimum commitment (C1)')
       end
     end
 
@@ -104,6 +109,7 @@ RSpec.describe Lago::Api::Resources::Plan do
         expect(plan.lago_id).to eq(plan_id)
         expect(plan.name).to eq(plan_name)
         expect(plan.invoice_display_name).to eq(plan_dsplay_name)
+        expect(plan.minimum_commitment.invoice_display_name).to eq('Minimum commitment (C1)')
       end
     end
 
@@ -164,6 +170,7 @@ RSpec.describe Lago::Api::Resources::Plan do
         expect(response['plans'].first['invoice_display_name']).to eq(plan_dsplay_name)
         expect(response['plans'].first['charges'].first['invoice_display_name']).to eq('Charge 1')
         expect(response['plans'].first['charges'].first['properties']['grouped_by']).to eq(['agent_name'])
+        expect(response['plans'].first['minimum_commitment']['invoice_display_name']).to eq('Minimum commitment (C1)')
         expect(response['meta']['current_page']).to eq(1)
       end
     end

--- a/spec/lago/api/resources/subscription_spec.rb
+++ b/spec/lago/api/resources/subscription_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Lago::Api::Resources::Subscription do
         ending_at: factory_subscription.ending_at,
         plan_overrides: {
           amount_cents: 1000,
+          minimum_commitment: {
+            amount_cents: 2000,
+            invoice_display_name: 'Minimum commitment (C1)',
+          },
         }
       }
     end
@@ -99,8 +103,8 @@ RSpec.describe Lago::Api::Resources::Subscription do
         stub_request(:delete, 'https://api.getlago.com/api/v1/subscriptions/456?status=pending')
         .to_return(body: response_with_pending, status: 200)
       end
-      
-      it 'returns subscription' do  
+
+      it 'returns subscription' do
         subscription = resource.destroy('456', options: { status: 'pending' })
 
         expect(subscription.external_customer_id).to eq(pending_subscription.external_customer_id)


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/set-minimum-spend-for-subscriptions

## Context

As a user, I want to define the minimum spend that applies to the customer's plan. Consider the following monthly plan:

- Subscription fee = $50 per month (in arrears);
- Usage-based charge = $10 per unit per month (in arrears); and
- Monthly minimum spend = $100.

If at the end of the month, the customer has consumed 3 units, their total invoice will be: $50 + 3 * $10 = $80 + $20 (true-up fee) = $100.

## Description

This PR adds minimum commitment to plan and plan overrides.