### PR TITLE
feat: Add recurring_transaction_rules to WalletsController#index

### DIFF
--- a/spec/lago/api/resources/wallet_spec.rb
+++ b/spec/lago/api/resources/wallet_spec.rb
@@ -175,6 +175,7 @@ RSpec.describe Lago::Api::Resources::Wallet do
             'granted_credits' => factory_wallet.granted_credits,
             'rate_amount' => factory_wallet.rate_amount,
             'created_at' => '2022-04-29T08:59:51Z',
+            'recurring_transaction_rules' => factory_wallet.recurring_transaction_rules,
           }
         ],
         'meta': {


### PR DESCRIPTION
The goal of this PR is to add `recurring_transaction_rules` to `WalletsController#index`.