### PR TITLE
feat(wallet): Add voided_credits to WalletTransaction

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lago-ruby-client (1.1.0)
+    lago-ruby-client (1.2.0)
       jwt
       openssl
 
@@ -16,7 +16,6 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
-    base64 (0.2.0)
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
@@ -32,8 +31,7 @@ GEM
     io-console (0.6.0)
     irb (1.6.3)
       reline (>= 0.3.0)
-    jwt (2.8.1)
-      base64
+    jwt (2.7.1)
     minitest (5.19.0)
     openssl (3.2.0)
     parallel (1.22.1)

--- a/lib/lago/api/resources/wallet_transaction.rb
+++ b/lib/lago/api/resources/wallet_transaction.rb
@@ -24,7 +24,8 @@ module Lago
             'wallet_transaction' => {
               wallet_id: params[:wallet_id],
               paid_credits: params[:paid_credits],
-              granted_credits: params[:granted_credits]
+              granted_credits: params[:granted_credits],
+              voided_credits: params[:voided_credits]
             }.compact
           }
         end

--- a/spec/factories/wallet_transaction.rb
+++ b/spec/factories/wallet_transaction.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     wallet_id { '123' }
     paid_credits { '100' }
     granted_credits { '100' }
+    voided_credits { '0' }
   end
 end


### PR DESCRIPTION
## Context

We want to differentiate a free wallet transaction vs. a paid wallet transaction.
And be able to void some wallet transactions.

## Description

This PR aims to create a voided wallet transaction.