### PR TITLE
feat(wallet): Rename wallet rule_type into trigger

### DIFF
--- a/lib/lago/api/resources/wallet.rb
+++ b/lib/lago/api/resources/wallet.rb
@@ -37,8 +37,8 @@ module Lago
               :lago_id,
               :paid_credits,
               :granted_credits,
-              :rule_type,
               :threshold_credits,
+              :trigger,
               :interval,
             )
 

--- a/spec/factories/wallet.rb
+++ b/spec/factories/wallet.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     recurring_transaction_rules do
       [
         {
-          rule_type: 'interval',
+          trigger: 'interval',
           interval: 'monthly',
           paid_credits: '105',
           granted_credits: '105',

--- a/spec/lago/api/resources/wallet_spec.rb
+++ b/spec/lago/api/resources/wallet_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Lago::Api::Resources::Wallet do
 
         expect(wallet.lago_id).to eq('this-is-lago-id')
         expect(wallet.name).to eq(factory_wallet.name)
-        expect(wallet.recurring_transaction_rules.first.rule_type).to eq('interval')
+        expect(wallet.recurring_transaction_rules.first.trigger).to eq('interval')
         expect(wallet.recurring_transaction_rules.first.interval).to eq('monthly')
       end
     end


### PR DESCRIPTION
## Context

After the release of real-time wallet version 1, some customers have expressed concerns about odd or missing behaviors.

## Description

The goal of this PR is to rename `Wallet#rule_type` into `Wallet#trigger`.