### PR TITLE
feat(wallet): Add method and target_ongoing_balance to recurring_transaction_rule

### DIFF
--- a/lib/lago/api/resources/wallet.rb
+++ b/lib/lago/api/resources/wallet.rb
@@ -40,6 +40,8 @@ module Lago
               :threshold_credits,
               :trigger,
               :interval,
+              :method,
+              :target_ongoing_balance,
             )
 
             processed_rules << result unless result.empty?

--- a/lib/lago/api/resources/wallet.rb
+++ b/lib/lago/api/resources/wallet.rb
@@ -41,6 +41,7 @@ module Lago
               :trigger,
               :interval,
               :method,
+              :started_at,
               :target_ongoing_balance,
             )
 

--- a/spec/factories/wallet.rb
+++ b/spec/factories/wallet.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
           interval: 'monthly',
           paid_credits: '105',
           granted_credits: '105',
+          started_at: nil,
           threshold_credits: '0',
           method: 'fixed'
         },

--- a/spec/factories/wallet.rb
+++ b/spec/factories/wallet.rb
@@ -13,6 +13,8 @@ FactoryBot.define do
           interval: 'monthly',
           paid_credits: '105',
           granted_credits: '105',
+          threshold_credits: '0',
+          method: 'fixed'
         },
       ]
     end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/define-a-target-balance-to-reach-for-recurring-top-up

## Context

We want to allow users to top-up their wallets to reach a specific target balance.

We can currently define a fixed top-up but we want to add the ability to specify a dynamic top-up (target balance to reach).

## Description

The goal of this PR is to add:

- `method`
- `target_ongoing_balance`
- `started_at`

to `recurring_transaction_rule`