### PR TITLE
feat(event): Add support for ingest API

### DIFF
--- a/lib/lago/api/client.rb
+++ b/lib/lago/api/client.rb
@@ -3,20 +3,30 @@
 module Lago
   module Api
     BASE_URL = 'https://api.getlago.com/'
+    BASE_INGEST_URL = 'https://ingest.getlago.com/'
     API_PATH = 'api/v1/'
 
     class Client
-      attr_reader :api_key, :api_url
+      attr_reader :api_key, :api_url, :use_ingest_service, :ingest_api_url
 
-      def initialize(api_key: nil, api_url: nil)
+      def initialize(api_key: nil, api_url: nil, use_ingest_service: false, ingest_api_url: nil)
         @api_key = api_key
         @api_url = api_url
+        @use_ingest_service = use_ingest_service
+        @ingest_api_url = ingest_api_url
       end
 
       def base_api_url
         base_url = api_url.nil? ? Lago::Api::BASE_URL : api_url
 
         URI.join(base_url, Lago::Api::API_PATH)
+      end
+
+      def base_ingest_api_url
+        return base_api_url unless use_ingest_service
+
+        ingest_url = ingest_api_url.nil? ? Lago::Api::BASE_INGEST_URL : ingest_api_url
+        URI.join(ingest_url, Lago::Api::API_PATH)
       end
 
       def customers

--- a/lib/lago/api/resources/event.rb
+++ b/lib/lago/api/resources/event.rb
@@ -12,6 +12,16 @@ module Lago
           'event'
         end
 
+        def create(params)
+          uri = URI("#{client.base_ingest_api_url}#{api_resource}")
+          connection = Lago::Api::Connection.new(client.api_key, uri)
+
+          payload = whitelist_params(params)
+          response = connection.post(payload, uri)[root_name]
+
+          JSON.parse(response.to_json, object_class: OpenStruct)
+        end
+
         def batch_create(params)
           uri = URI("#{client.base_api_url}#{api_resource}/batch")
 

--- a/spec/lago/api/client_spec.rb
+++ b/spec/lago/api/client_spec.rb
@@ -3,14 +3,14 @@
 require 'spec_helper'
 
 RSpec.describe Lago::Api::Client do
-  let(:api_url) { 'http://test.api.url/' }
-
   subject(:client) do
     described_class.new(
       api_key: '123456',
-      api_url: api_url
+      api_url: api_url,
     )
   end
+
+  let(:api_url) { 'http://test.api.url/' }
 
   describe '#base_api_url' do
     context 'when api_url is given' do
@@ -21,6 +21,36 @@ RSpec.describe Lago::Api::Client do
       let(:api_url) { nil }
 
       it { expect(client.base_api_url).to eq(URI('https://api.getlago.com/api/v1/')) }
+    end
+  end
+
+  describe '#base_ingest_api_url' do
+    subject(:client) do
+      described_class.new(
+        api_key: '123456',
+        api_url: api_url,
+        use_ingest_service: use_ingest_service,
+        ingest_api_url: ingest_api_url,
+      )
+    end
+
+    let(:use_ingest_service) { false }
+    let(:ingest_api_url) { nil }
+
+    context 'when use_ingest_service flag is false' do
+      it { expect(client.base_ingest_api_url).to eq(URI("#{api_url}api/v1/")) }
+    end
+
+    context 'when use_ingest_service flag is true' do
+      let(:use_ingest_service) { true }
+
+      it { expect(client.base_ingest_api_url).to eq(URI('https://ingest.getlago.com/api/v1/')) }
+
+      context 'when a base_ingest_url is provided' do
+        let(:ingest_api_url) { 'http://ingest.api.url/' }
+
+        it { expect(client.base_ingest_api_url).to eq(URI("#{ingest_api_url}api/v1/")) }
+      end
     end
   end
 end

--- a/spec/lago/api/resources/event_spec.rb
+++ b/spec/lago/api/resources/event_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe Lago::Api::Resources::Event do
         expect(event.lago_id).to eq('1a901a90-1a90-1a90-1a90-1a901a901a90')
       end
     end
+
+    context 'when ingest url is used' do
+      let(:client) { Lago::Api::Client.new(use_ingest_service: true) }
+
+      before do
+        stub_request(:post, 'https://ingest.getlago.com/api/v1/events')
+          .with(body: { event: params })
+          .to_return(body: event_response, status: 200)
+      end
+
+      it 'returns true' do
+        event = resource.create(params)
+
+        expect(event.lago_id).to eq('1a901a90-1a90-1a90-1a90-1a901a901a90')
+      end
+    end
   end
 
   describe '#batch_create' do


### PR DESCRIPTION
This PR adds the support for the future ingest API for events on Lago US cluster.

Support for EU cluster and self-hosted will come later