### PR TITLE
feat(customers): add support for shippig address

### DIFF
--- a/lib/lago/api/resources/customer.rb
+++ b/lib/lago/api/resources/customer.rb
@@ -78,6 +78,10 @@ module Lago
             result_hash[:billing_configuration] = config unless config.empty?
           end
 
+          whitelist_shipping_address(params[:shipping_address]).tap do |address|
+            result_hash[:shipping_address] = address unless address.empty?
+          end
+
           integration_customers = whitelist_integration_customers(params[:integration_customers])
           result_hash[:integration_customers] = integration_customers unless integration_customers.empty?
 
@@ -97,6 +101,17 @@ module Lago
             :sync_with_provider,
             :document_locale,
             :provider_payment_methods,
+          )
+        end
+
+        def whitelist_shipping_address(address)
+          (address || {}).slice(
+            :address_line1,
+            :address_line2,
+            :city,
+            :zipcode,
+            :state,
+            :country,
           )
         end
 

--- a/spec/factories/customer.rb
+++ b/spec/factories/customer.rb
@@ -28,6 +28,15 @@ FactoryBot.define do
         document_locale: 'fr',
       }
     end
+    shipping_address do
+      {
+        address_line1: '5230 Penfield Ave',
+        city: 'Woodland Hills',
+        zipcode: '91364',
+        state: 'CA',
+        country: 'US',
+      }
+    end
     integration_customers do
       [
         {

--- a/spec/fixtures/api/customer.json
+++ b/spec/fixtures/api/customer.json
@@ -30,6 +30,13 @@
       "document_locale": "fr",
       "provider_payment_methods": ["card"]
     },
+    "shipping_address": {
+      "address_line1": "5230 Penfield Ave",
+      "city": "Woodland Hills",
+      "zipcode": "91364",
+      "state": "CA",
+      "country": "US"
+    },
     "integration_customers": [
       {
         "lago_id": "123asd123lkj987lkj",

--- a/spec/lago/api/resources/customer_spec.rb
+++ b/spec/lago/api/resources/customer_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe Lago::Api::Resources::Customer do
         expect(customer.billing_configuration.invoice_grace_period).to eq(3)
         expect(customer.billing_configuration.provider_customer_id).to eq('cus_12345')
         expect(customer.billing_configuration.provider_payment_methods).to eq(['card'])
+        expect(customer.shipping_address.city).to eq('Woodland Hills')
+        expect(customer.shipping_address.country).to eq('US')
         expect(customer.integration_customers.first.external_customer_id).to eq('123456789')
         expect(customer.integration_customers.first.type).to eq('netsuite')
         expect(customer.metadata.first.key).to eq('key')


### PR DESCRIPTION
This PR adds support for shipping address that will be used in tax integrations.