### PR TITLE
misc(version): Bump to v1.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lago-ruby-client (1.6.0)
+    lago-ruby-client (1.7.0)
       jwt
       openssl
 

--- a/lib/lago/version.rb
+++ b/lib/lago/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lago
-  VERSION = '1.6.0'
+  VERSION = '1.7.0'
 end


### PR DESCRIPTION
## :warning:  **Reminder: API changes**

As announced a few months ago, this release updates the event ingestion process and removes deprecated API fields.
Changes include:

### :one: Replacing groups with filters
The new dimension system based on filters is already available. It allows users to create billable metrics with more than two dimensions, and makes it easier to create charges based on custom event properties. The former dimension system based on groups is now permanently removed from the Lago API ([see all changes](https://docs.getlago.com/guide/migration/migration-to-v1.2.0#1-transition-from-group-to-filters)).

### :two: Marking  external_subscription_id as mandatory for events
Events that only include external_customer_id will no longer be taken into account when aggregating usage ([learn more](https://docs.getlago.com/guide/migration/migration-to-v1.2.0#2-mandatory-external-subscription-id-field-in-event-payloads)). This change will streamline the event validation process and enable real-time billing capabilities.

### :three: Removing deprecated API fields
For the sake of clarity and to preserve the quality of the API, we’ve deprecated several legacy fields ([see full list](https://docs.getlago.com/guide/migration/migration-to-v1.2.0#3-deprecated-fields)).

:point_right: [Migration to v1.2.0 (full post)](https://docs.getlago.com/guide/migration/migration-to-v1.2.0)