### PR TITLE
Feat(anrok): update ruby-client with retry method for invoice

### DIFF
--- a/lib/lago/api/resources/invoice.rb
+++ b/lib/lago/api/resources/invoice.rb
@@ -56,6 +56,13 @@ module Lago
           JSON.parse(response.to_json, object_class: OpenStruct)
         end
 
+        def retry(invoice_id)
+          path = "/api/v1/invoices/#{invoice_id}/retry"
+          response = connection.post({}, path)
+
+          JSON.parse(response.to_json, object_class: OpenStruct).invoice
+        end
+
         def payment_url(invoice_id)
           path = "/api/v1/invoices/#{invoice_id}/payment_url"
           response = connection.post({}, path)['invoice_payment_details']

--- a/spec/lago/api/resources/invoice_spec.rb
+++ b/spec/lago/api/resources/invoice_spec.rb
@@ -281,6 +281,20 @@ RSpec.describe Lago::Api::Resources::Invoice do
     end
   end
 
+  describe '#retry' do
+    before do
+      stub_request(:post, "https://api.getlago.com/api/v1/invoices/#{invoice_id}/retry")
+        .with(body: {}).to_return(body: invoice_response, status: 200)
+    end
+
+    it 'returns invoice' do
+      result = resource.retry(invoice_id)
+
+      expect(result.lago_id).to eq(invoice_id)
+      expect(result.status).to eq('finalized')
+    end
+  end
+
   describe '#payment_url' do
     let(:url_response) do
       {


### PR DESCRIPTION
Added support of `/retry` method on invoice for failed invoices