### PR TITLE
feat(ProgressiveBilling): Expose lifetime usage GET and PUT

### DIFF
--- a/lib/lago/api/resources/subscription.rb
+++ b/lib/lago/api/resources/subscription.rb
@@ -12,6 +12,27 @@ module Lago
           'subscription'
         end
 
+        def lifetime_usage(external_subscription_id)
+          uri = URI(
+            "#{client.base_api_url}#{api_resource}/#{external_subscription_id}/lifetime_usage",
+          )
+          response = connection.get(uri, identifier: nil)
+          JSON.parse(response.to_json, object_class: OpenStruct).lifetime_usage
+        end
+
+        def update_lifetime_usage(external_subscription_id, params)
+          uri = URI(
+            "#{client.base_api_url}#{api_resource}/#{external_subscription_id}/lifetime_usage",
+          )
+
+          response = connection.put(
+            uri,
+            identifier: nil,
+            body: whitelist_lifetime_usage_params(params),
+          )
+          JSON.parse(response.to_json, object_class: OpenStruct).lifetime_usage
+        end
+
         def whitelist_params(params)
           {
             root_name => {
@@ -24,6 +45,14 @@ module Lago
               ending_at: params[:ending_at],
               plan_overrides: params[:plan_overrides],
             }.compact,
+          }
+        end
+
+        def whitelist_lifetime_usage_params(params)
+          {
+            lifetime_usage: {
+              external_historical_usage_amount_cents: params[:external_historical_usage_amount_cents],
+            },
           }
         end
       end

--- a/spec/factories/lifetime_usage.rb
+++ b/spec/factories/lifetime_usage.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :update_lifetime_usage, class: OpenStruct do
+    external_historical_usage_amount_cents { 100 }
+  end
+end

--- a/spec/fixtures/api/subscription_lifetime_usage.json
+++ b/spec/fixtures/api/subscription_lifetime_usage.json
@@ -1,0 +1,24 @@
+{
+  "lifetime_usage": {
+    "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+    "lago_subscription_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+    "external_subscription_id": "sub-12345",
+    "external_historical_usage_amount_cents": 20,
+    "invoiced_usage_amount_cents": 2000,
+    "current_usage_amount_cents": 100,
+    "from_datetime": "2022-04-29T08:59:51Z",
+    "to_datetime": "2024-02-10T08:59:51Z",
+    "usage_thresholds": [
+      {
+        "amount_cents": 100,
+        "completion_ratio": 1.0,
+        "reached_at": "2024-01-09T08:59:51Z"
+      },
+      {
+        "amount_cents": 3000,
+        "completion_ratio": "0.6733333",
+        "reached_at": null
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR adds new routes to fetch and update the lifetime usage of a subscription