### PR TITLE
feat(DynamicPricing): Expose Event#precise_total_amount_cents

### DIFF
--- a/lib/lago/api/resources/event.rb
+++ b/lib/lago/api/resources/event.rb
@@ -43,6 +43,7 @@ module Lago
               code: params[:code],
               timestamp: params[:timestamp],
               external_subscription_id: params[:external_subscription_id],
+              precise_total_amount_cents: params[:precise_total_amount_cents],
               properties: params[:properties],
             }.compact,
           }
@@ -59,6 +60,7 @@ module Lago
             root_name => {
               code: params[:code],
               external_subscription_id: params[:external_subscription_id],
+              precise_total_amount_cents: params[:precise_total_amount_cents],
               properties: params[:properties],
             }.compact,
           }

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     external_subscription_id { '5eb02857-a71e-4ea2-bcf9-57d8885990ba' }
     code { '123' }
     timestamp { '2022-05-05T12:27:30Z' }
+    precise_total_amount_cents { '1000.12' }
     properties do
       {
         'custom_field' => 'custom'

--- a/spec/fixtures/api/event.json
+++ b/spec/fixtures/api/event.json
@@ -5,6 +5,7 @@
     "lago_customer_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
     "code": "bm_code",
     "timestamp": "2022-04-29T08:59:51.998Z",
+    "precise_total_amount_cents": null,
     "properties": {
       "custom_field": 12
     },


### PR DESCRIPTION
## Context

AI, CPaaS and Fintech customers can apply a price to a unit that fluctuates over time. Currently Lago does not support this usecase.

## Description

This PR is related to https://github.com/getlago/lago-api/pull/2610.
It documents the new `precise_total_amount_cents` in input and result payloads on `POST /api/v1/events` and `POST /api/v1/batch_events`