### PR TITLE
feat(fee): Expose charge_id

### DIFF
--- a/spec/fixtures/api/fee.json
+++ b/spec/fixtures/api/fee.json
@@ -1,6 +1,7 @@
 {
   "fee": {
     "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "lago_charge_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
     "lago_charge_filter_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
     "lago_invoice_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
     "lago_true_up_fee_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",

--- a/spec/fixtures/api/invoice.json
+++ b/spec/fixtures/api/invoice.json
@@ -107,6 +107,7 @@
     "fees": [
       {
         "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+        "lago_charge_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
         "item": {
           "type": "charge",
           "code": "seats",


### PR DESCRIPTION
## Pull Request template

Related to https://github.com/getlago/lago-api/pull/2710

Exposes the new `fees#charge_id` field