### PR TITLE
misc: Remove *_count fields

### DIFF
--- a/spec/fixtures/api/billable_metric.json
+++ b/spec/fixtures/api/billable_metric.json
@@ -17,9 +17,6 @@
         "key": "country",
         "values": ["france", "italy", "spain"]
       }
-    ],
-    "active_subscriptions_count": 0,
-    "draft_invoices_count": 0,
-    "plans_count": 0
+    ]
   }
 }

--- a/spec/fixtures/api/billable_metric_index.json
+++ b/spec/fixtures/api/billable_metric_index.json
@@ -13,10 +13,7 @@
       "expression": "1 + 2",
       "field_name": "amount_sum",
       "created_at": "2022-04-29T08:59:51Z",
-      "filters": [],
-      "active_subscriptions_count": 0,
-      "draft_invoices_count": 0,
-      "plans_count": 0
+      "filters": []
     },
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314a11111",
@@ -31,10 +28,7 @@
       "expression": "1 + 2",
       "field_name": "amount_sum",
       "created_at": "2022-04-30T08:59:51Z",
-      "filters": [],
-      "active_subscriptions_count": 0,
-      "draft_invoices_count": 0,
-      "plans_count": 0
+      "filters": []
     }
   ],
   "meta": {

--- a/spec/fixtures/api/plan.json
+++ b/spec/fixtures/api/plan.json
@@ -12,8 +12,6 @@
     "trial_period": 3.0,
     "pay_in_advance": true,
     "bill_charges_monthly": null,
-    "active_subscriptions_count": 0,
-    "draft_invoices_count": 0,
     "charges": [
       {
         "lago_id": "51c1e851-5be6-4343-a0ee-39a81d8b4ee1",
@@ -29,9 +27,7 @@
         "min_amount_cents": 0,
         "properties": {
           "amount": "0.22",
-          "grouped_by": [
-            "agent_name"
-          ]
+          "grouped_by": ["agent_name"]
         },
         "filters": [
           {
@@ -40,9 +36,7 @@
               "amount": "0.33"
             },
             "values": {
-              "country": [
-                "France"
-              ]
+              "country": ["France"]
             }
           }
         ],
@@ -84,10 +78,6 @@
         "code": "tax_code",
         "rate": 15.0,
         "description": "tax_desc",
-        "add_ons_count": 0,
-        "customers_count": 0,
-        "plans_count": 0,
-        "charges_count": 0,
         "applied_to_organization": false,
         "created_at": "2022-04-29T08:59:51Z"
       }

--- a/spec/fixtures/api/plans.json
+++ b/spec/fixtures/api/plans.json
@@ -13,8 +13,6 @@
       "trial_period": 3.0,
       "pay_in_advance": true,
       "bill_charges_monthly": null,
-      "active_subscriptions_count": 0,
-      "draft_invoices_count": 0,
       "charges": [
         {
           "lago_id": "51c1e851-5be6-4343-a0ee-39a81d8b4ee1",
@@ -29,9 +27,7 @@
           "invoice_display_name": "Charge 1",
           "properties": {
             "amount": "0.22",
-            "grouped_by": [
-              "agent_name"
-            ]
+            "grouped_by": ["agent_name"]
           },
           "filters": [
             {
@@ -40,9 +36,7 @@
                 "amount": "0.33"
               },
               "values": {
-                "country": [
-                  "France"
-                ]
+                "country": ["France"]
               }
             }
           ]
@@ -80,8 +74,6 @@
       "trial_period": 2.0,
       "pay_in_advance": true,
       "bill_charges_monthly": null,
-      "active_subscriptions_count": 0,
-      "draft_invoices_count": 0,
       "charges": [
         {
           "lago_id": "dfdc725d-6341-4d61-831e-4ac9ccd509c0",
@@ -111,8 +103,6 @@
       "trial_period": 0.0,
       "pay_in_advance": true,
       "bill_charges_monthly": null,
-      "active_subscriptions_count": 0,
-      "draft_invoices_count": 0,
       "charges": []
     }
   ],

--- a/spec/fixtures/api/tax.json
+++ b/spec/fixtures/api/tax.json
@@ -5,10 +5,6 @@
     "code": "tax_code",
     "rate": 15.0,
     "description": "tax_desc",
-    "add_ons_count": 0,
-    "customers_count": 0,
-    "plans_count": 0,
-    "charges_count": 0,
     "applied_to_organization": false,
     "created_at": "2022-04-29T08:59:51Z"
   }

--- a/spec/fixtures/api/taxes.json
+++ b/spec/fixtures/api/taxes.json
@@ -6,10 +6,6 @@
       "code": "tax_code",
       "rate": 15.0,
       "description": "tax_desc",
-      "add_ons_count": 0,
-      "customers_count": 0,
-      "plans_count": 0,
-      "charges_count": 0,
       "applied_to_organization": false,
       "created_at": "2022-04-29T08:59:51Z"
     }


### PR DESCRIPTION
# Context

The API response are returning a lot of counters. Since the exposed resources can be linked to a lot of objects and can be called a lot, these counters are posing a scalability problem and are slowing down the global performance of the API.

To remediate the situation the decision was made to remove all these fields.

# Changes

This PR removes the following fields:
- BillableMetric
  -  active_subscriptions_count
  - draft_invoices_count
  - plans_count
- Plan
  - active_subscriptions_count
  - draft_invoices_count
- Tax
  - add_ons_count
  - charges_count
  - customers_count
  - plans_count