### PR TITLE
misc: Update supported ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Ruby CI
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -12,12 +12,11 @@ permissions:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ["3.1", "3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ["3.1", "3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v3
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: "3.1"
 
       - name: Publish to RubyGems
         run: |
@@ -43,4 +43,4 @@ jobs:
           gem build *.gemspec
           gem push *.gem
         env:
-          GEM_HOST_API_KEY: '${{secrets.RUBYGEMS_API_KEY}}'
+          GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_API_KEY}}"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.2.0)
+    bigdecimal (3.1.9)
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
@@ -37,6 +38,8 @@ GEM
       base64
     language_server-protocol (3.17.0.3)
     minitest (5.19.0)
+    mutex_m (0.3.0)
+    observer (0.1.2)
     openssl (3.2.0)
     parallel (1.26.3)
     parser (3.3.4.2)
@@ -91,9 +94,12 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bigdecimal
   debug (>= 1.0.0)
   factory_bot
   lago-ruby-client!
+  mutex_m
+  observer
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)

--- a/lago-ruby-client.gemspec
+++ b/lago-ruby-client.gemspec
@@ -27,6 +27,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency('openssl')
 
   spec.add_development_dependency 'debug', '>= 1.0.0'
+  spec.add_development_dependency 'observer'
+  spec.add_development_dependency 'mutex_m'
+  spec.add_development_dependency 'bigdecimal'
   spec.add_development_dependency 'factory_bot'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
This PR:
- Removes support for ruby 2.7 as it is unsupported for a long time now 
- Adds support for ruby 3.4