### PR TITLE
feat: add apply taxes params to current usage

### DIFF
--- a/lib/lago/api/resources/customer.rb
+++ b/lib/lago/api/resources/customer.rb
@@ -12,11 +12,12 @@ module Lago
           'customer'
         end
 
-        def current_usage(external_customer_id, external_subscription_id)
-          uri = URI(
-            "#{client.base_api_url}#{api_resource}/#{external_customer_id}" \
-              "/current_usage?external_subscription_id=#{external_subscription_id}",
-          )
+        def current_usage(external_customer_id, external_subscription_id, apply_taxes: nil)
+          query_params = { external_subscription_id: external_subscription_id }
+          query_params[:apply_taxes] = apply_taxes unless apply_taxes.nil?
+          query_string = URI.encode_www_form(query_params)
+
+          uri = URI("#{client.base_api_url}#{api_resource}/#{external_customer_id}/current_usage?#{query_string}")
           connection.get(uri, identifier: nil)
         end
 

--- a/spec/lago/api/resources/customer_spec.rb
+++ b/spec/lago/api/resources/customer_spec.rb
@@ -87,6 +87,20 @@ RSpec.describe Lago::Api::Resources::Customer do
       end
     end
 
+    context 'when the optional apply_taxes parameter is provided' do
+      let(:apply_taxes) { 'true' }
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{customer_external_id}/current_usage")
+          .with(query: { external_subscription_id: subscription_external_id, apply_taxes: apply_taxes })
+          .to_return(body: customer_usage_response, status: 200)
+      end
+
+      it 'returns the usage of the customer with apply_taxes applied' do
+        response = resource.current_usage(customer_external_id, subscription_external_id, apply_taxes: apply_taxes)
+        expect(response['customer_usage']['from_datetime']).to eq('2022-07-01T00:00:00Z')
+      end
+    end
+
     context 'when the customer does not exists' do
       let(:customer_external_id) { 'DOESNOTEXIST' }
 


### PR DESCRIPTION
Updated the current_usage method to accept an optional apply_taxes parameter, defaulting to True. This parameter is included in the query string as a lowercase string ("true" or "false").