### PR TITLE
feat(wallets): add support for wallet bm limitation

### DIFF
--- a/lib/lago/api/resources/wallet.rb
+++ b/lib/lago/api/resources/wallet.rb
@@ -60,7 +60,7 @@ module Lago
         end
 
         def whitelist_applies_to(applies_to_params)
-          (applies_to_params || {}).slice(:fee_types)
+          (applies_to_params || {}).slice(:fee_types, :billable_metric_codes)
         end
       end
     end

--- a/spec/factories/wallet.rb
+++ b/spec/factories/wallet.rb
@@ -8,7 +8,8 @@ FactoryBot.define do
     granted_credits { '100' }
     applies_to do
       {
-        fee_types: %w[charge]
+        fee_types: %w[charge],
+        billable_metric_codes: %w[bm1]
       }
     end
     recurring_transaction_rules do

--- a/spec/lago/api/resources/wallet_spec.rb
+++ b/spec/lago/api/resources/wallet_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Lago::Api::Resources::Wallet do
           factory_wallet.recurring_transaction_rules.first[:expiration_at]
         )
         expect(wallet.applies_to.fee_types).to eq(factory_wallet.applies_to[:fee_types])
+        expect(wallet.applies_to.billable_metric_codes).to eq(factory_wallet.applies_to[:billable_metric_codes])
       end
     end
 


### PR DESCRIPTION
This PR adds support for limiting wallet consumption on specific billable metric types.

New attribute called `billable_metric_codes` is added inside `applies_to` object in both request and response.