### PR TITLE
feat(pricing-units): Add support for pricing units

### DIFF
--- a/lib/lago/api/resources/plan.rb
+++ b/lib/lago/api/resources/plan.rb
@@ -67,7 +67,7 @@ module Lago
               :properties,
               :filters,
               :tax_codes,
-              :applied_pricing_unit
+              :applied_pricing_unit,
             )
 
             processed_charges << result unless result.empty?


### PR DESCRIPTION
Since we have no types – there's only input params that need to be updated.
On input params for `subscription` we have permit `plan_override` which will allow everything inside.
For `plan` only this keep seems to be needed.