### PR TITLE
feat(wallet-transaction): Add a `name` to wallet transactions

### DIFF
--- a/lib/lago/api/resources/wallet_transaction.rb
+++ b/lib/lago/api/resources/wallet_transaction.rb
@@ -32,6 +32,7 @@ module Lago
           {
             'wallet_transaction' => {
               wallet_id: params[:wallet_id],
+              name: params[:name],
               paid_credits: params[:paid_credits],
               granted_credits: params[:granted_credits],
               voided_credits: params[:voided_credits],

--- a/spec/factories/wallet_transaction.rb
+++ b/spec/factories/wallet_transaction.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     paid_credits { '100' }
     granted_credits { '100' }
     voided_credits { '0' }
+    name { 'Transaction Name' }
   end
 end

--- a/spec/lago/api/resources/wallet_transaction_spec.rb
+++ b/spec/lago/api/resources/wallet_transaction_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Lago::Api::Resources::WalletTransaction do
           'lago_id' => 'this-is-lago-id',
           'lago_wallet_id' => factory_wallet_transaction.wallet_id,
           'amount' => factory_wallet_transaction.paid_credits,
+          'name' => factory_wallet_transaction.name,
           'status' => 'pending',
           'transaction_status' => 'purchased',
           'transaction_type' => 'inbound',
@@ -25,6 +26,7 @@ RSpec.describe Lago::Api::Resources::WalletTransaction do
           'lago_id' => 'this-is-lago-id2',
           'lago_wallet_id' => factory_wallet_transaction.wallet_id,
           'amount' => factory_wallet_transaction.granted_credits,
+          'name' => factory_wallet_transaction.name,
           'status' => 'settled',
           'transaction_status' => 'purchased',
           'transaction_type' => 'inbound',
@@ -44,10 +46,25 @@ RSpec.describe Lago::Api::Resources::WalletTransaction do
   end
 
   describe '#create' do
-    let(:params) { factory_wallet_transaction.to_h }
+    let(:params) do
+      {
+        wallet_id: "123",
+        name: "Transaction Name",
+        paid_credits: "100",
+        granted_credits: "100",
+        voided_credits: "0",
+        extra_param: "extra_value"
+      }
+    end
     let(:body) do
       {
-        'wallet_transaction' => factory_wallet_transaction.to_h
+        'wallet_transaction' => {
+          "wallet_id" => "123",
+          "name" => "Transaction Name",
+          "paid_credits" => "100",
+          "granted_credits" => "100",
+          "voided_credits" => "0"
+        }
       }
     end
 
@@ -63,6 +80,7 @@ RSpec.describe Lago::Api::Resources::WalletTransaction do
 
         expect(wallet_transactions.first.lago_id).to eq('this-is-lago-id')
         expect(wallet_transactions.last.lago_id).to eq('this-is-lago-id2')
+        expect(wallet_transactions).to all(have_attributes(name: 'Transaction Name'))
       end
     end
 


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-the-name-of-a-wallet-transaction-at-top-up

## Context

Follow up of https://github.com/getlago/lago-api/pull/4256.

## Description

This implements the new input/field on wallet transactions and add tests for those. 