### PR TITLE
feat(wallet-transaction): Add `transaction_name` to wallet transaction rules

### DIFF
--- a/lib/lago/api/resources/wallet.rb
+++ b/lib/lago/api/resources/wallet.rb
@@ -52,7 +52,8 @@ module Lago
               :started_at,
               :expiration_at,
               :target_ongoing_balance,
-              :transaction_metadata
+              :transaction_metadata,
+              :transaction_name
             )
 
             processed_rules << result unless result.empty?

--- a/spec/factories/wallet.rb
+++ b/spec/factories/wallet.rb
@@ -22,7 +22,8 @@ FactoryBot.define do
           started_at: nil,
           expiration_at: '2026-12-31T23:59:59Z',
           threshold_credits: '0',
-          method: 'fixed'
+          method: 'fixed',
+          transaction_name: 'Recurring Transaction Rule'
         },
       ]
     end

--- a/spec/lago/api/resources/wallet_spec.rb
+++ b/spec/lago/api/resources/wallet_spec.rb
@@ -34,14 +34,35 @@ RSpec.describe Lago::Api::Resources::Wallet do
     let(:params) { factory_wallet.to_h }
     let(:body) do
       {
-        'wallet' => factory_wallet.to_h,
+        'wallet' => {
+          'external_customer_id' => '12345',
+          'rate_amount' => '1',
+          'name' => 'wallet name',
+          'paid_credits' => '100',
+          'granted_credits' => '100',
+          'expiration_at' => '2022-07-07T23:59:59Z',
+          'recurring_transaction_rules' => [
+            {
+              'paid_credits' => '105',
+              'granted_credits' => '105',
+              'threshold_credits' => '0',
+              'trigger' => 'interval',
+              'interval' => 'monthly',
+              'method' => 'fixed',
+              'started_at' => nil,
+              'expiration_at' => '2026-12-31T23:59:59Z',
+              'transaction_name' => 'Recurring Transaction Rule'
+            }
+          ],
+          'applies_to' => { 'fee_types' => ['charge'], 'billable_metric_codes' => ['bm1'] }
+        }
       }
     end
 
     context 'when wallet is successfully created' do
       before do
         stub_request(:post, 'https://api.getlago.com/api/v1/wallets')
-          .with(body: body)
+          .with(body:)
           .to_return(body: response, status: 200)
       end
 
@@ -53,6 +74,7 @@ RSpec.describe Lago::Api::Resources::Wallet do
         expect(wallet.expiration_at).to eq(factory_wallet.expiration_at)
         expect(wallet.recurring_transaction_rules.first.trigger).to eq('interval')
         expect(wallet.recurring_transaction_rules.first.interval).to eq('monthly')
+        expect(wallet.recurring_transaction_rules.first.transaction_name).to eq('Recurring Transaction Rule')
         expect(wallet.recurring_transaction_rules.first.expiration_at).to eq(
           factory_wallet.recurring_transaction_rules.first[:expiration_at]
         )
@@ -75,11 +97,32 @@ RSpec.describe Lago::Api::Resources::Wallet do
   end
 
   describe '#update' do
-    let(:params) { { name: 'new-name' } }
+    let(:params) { factory_wallet.to_h }
     let(:id) { 'id' }
     let(:body) do
       {
-        'wallet' => { name: 'new-name' },
+        'wallet' => {
+          'external_customer_id' => '12345',
+          'rate_amount' => '1',
+          'name' => 'wallet name',
+          'paid_credits' => '100',
+          'granted_credits' => '100',
+          'expiration_at' => '2022-07-07T23:59:59Z',
+          'recurring_transaction_rules' => [
+            {
+              'paid_credits' => '105',
+              'granted_credits' => '105',
+              'threshold_credits' => '0',
+              'trigger' => 'interval',
+              'interval' => 'monthly',
+              'method' => 'fixed',
+              'started_at' => nil,
+              'expiration_at' => '2026-12-31T23:59:59Z',
+              'transaction_name' => 'Recurring Transaction Rule'
+            }
+          ],
+          'applies_to' => { 'fee_types' => ['charge'], 'billable_metric_codes' => ['bm1'] }
+        }
       }
     end
 

--- a/spec/lago/api/resources/wallet_spec.rb
+++ b/spec/lago/api/resources/wallet_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Lago::Api::Resources::Wallet do
     context 'when wallet is successfully created' do
       before do
         stub_request(:post, 'https://api.getlago.com/api/v1/wallets')
-          .with(body:)
+          .with(body: body)
           .to_return(body: response, status: 200)
       end
 


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-the-name-of-a-wallet-transaction-at-top-up

## Context

Follow up of https://github.com/getlago/lago-api/pull/4282.

## Description

This adds a `transaction_name` to the wallet transaction recurring rule types that are then used to populate the name of the triggered wallet transactions.

