### PR TITLE
feat(customers): Add new routes scoped to cusomters

### DIFF
--- a/lib/lago/api/client.rb
+++ b/lib/lago/api/client.rb
@@ -10,6 +10,14 @@ require 'lago/api/resources/billing_entity'
 require 'lago/api/resources/coupon'
 require 'lago/api/resources/credit_note'
 require 'lago/api/resources/customer'
+require 'lago/api/resources/customers/base'
+require 'lago/api/resources/customers/applied_coupon'
+require 'lago/api/resources/customers/credit_note'
+require 'lago/api/resources/customers/invoice'
+require 'lago/api/resources/customers/payment'
+require 'lago/api/resources/customers/payment_request'
+require 'lago/api/resources/customers/subscription'
+require 'lago/api/resources/customers/wallet'
 require 'lago/api/resources/event'
 require 'lago/api/resources/feature'
 require 'lago/api/resources/fee'
@@ -96,6 +104,34 @@ module Lago
 
       def customers
         Resources::Customer.new(self)
+      end
+
+      def customer_applied_coupons(resource_id)
+        Resources::Customers::AppliedCoupon.new(self, resource_id)
+      end
+
+      def customer_credit_notes(resource_id)
+        Resources::Customers::CreditNote.new(self, resource_id)
+      end
+
+      def customer_invoices(resource_id)
+        Resources::Customers::Invoice.new(self, resource_id)
+      end
+
+      def customer_payments(resource_id)
+        Resources::Customers::Payment.new(self, resource_id)
+      end
+
+      def customer_payment_requests(resource_id)
+        Resources::Customers::PaymentRequest.new(self, resource_id)
+      end
+
+      def customer_subscriptions(resource_id)
+        Resources::Customers::Subscription.new(self, resource_id)
+      end
+
+      def customer_wallets(resource_id)
+        Resources::Customers::Wallet.new(self, resource_id)
       end
 
       def events

--- a/lib/lago/api/resources/customers/applied_coupon.rb
+++ b/lib/lago/api/resources/customers/applied_coupon.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'lago/api/resources/base'
+
+module Lago
+  module Api
+    module Resources
+      module Customers
+        class AppliedCoupon < Base
+          def api_resource
+            "#{base_api_resource}/applied_coupons"
+          end
+
+          def root_name
+            'applied_coupon'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/lago/api/resources/customers/base.rb
+++ b/lib/lago/api/resources/customers/base.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'lago/api/resources/base'
+
+module Lago
+  module Api
+    module Resources
+      module Customers
+        class Base < Lago::Api::Resources::Base
+          def initialize(client, resource_id)
+            super(client)
+            @resource_id = resource_id
+          end
+
+          def base_api_resource
+            "customers/#{resource_id}"
+          end
+
+          def create(params)
+            raise NotImplementedError
+          end
+
+          def update(params, identifier = nil)
+            raise NotImplementedError
+          end
+
+          def get(identifier)
+            raise NotImplementedError
+          end
+
+          def destroy(identifier, options: nil)
+            raise NotImplementedError
+          end
+
+          private
+
+          attr_reader :resource_id
+        end
+      end
+    end
+  end
+end

--- a/lib/lago/api/resources/customers/credit_note.rb
+++ b/lib/lago/api/resources/customers/credit_note.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'lago/api/resources/base'
+
+module Lago
+  module Api
+    module Resources
+      module Customers
+        class CreditNote < Base
+          def api_resource
+            "#{base_api_resource}/credit_notes"
+          end
+
+          def root_name
+            'credit_note'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/lago/api/resources/customers/invoice.rb
+++ b/lib/lago/api/resources/customers/invoice.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'lago/api/resources/base'
+
+module Lago
+  module Api
+    module Resources
+      module Customers
+        class Invoice < Base
+          def api_resource
+            "#{base_api_resource}/invoices"
+          end
+
+          def root_name
+            'invoice'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/lago/api/resources/customers/payment.rb
+++ b/lib/lago/api/resources/customers/payment.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'lago/api/resources/base'
+
+module Lago
+  module Api
+    module Resources
+      module Customers
+        class Payment < Base
+          def api_resource
+            "#{base_api_resource}/payments"
+          end
+
+          def root_name
+            'payment'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/lago/api/resources/customers/payment_request.rb
+++ b/lib/lago/api/resources/customers/payment_request.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'lago/api/resources/base'
+
+module Lago
+  module Api
+    module Resources
+      module Customers
+        class PaymentRequest < Base
+          def api_resource
+            "#{base_api_resource}/payment_requests"
+          end
+
+          def root_name
+            'payment_request'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/lago/api/resources/customers/subscription.rb
+++ b/lib/lago/api/resources/customers/subscription.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'lago/api/resources/base'
+
+module Lago
+  module Api
+    module Resources
+      module Customers
+        class Subscription < Base
+          def api_resource
+            "#{base_api_resource}/subscriptions"
+          end
+
+          def root_name
+            'subscription'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/lago/api/resources/customers/wallet.rb
+++ b/lib/lago/api/resources/customers/wallet.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'lago/api/resources/base'
+
+module Lago
+  module Api
+    module Resources
+      module Customers
+        class Wallet < Base
+          def api_resource
+            "#{base_api_resource}/wallets"
+          end
+
+          def root_name
+            'wallet'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/api/applied_coupon.json
+++ b/spec/fixtures/api/applied_coupon.json
@@ -1,0 +1,17 @@
+{
+  "applied_coupon": {
+    "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
+    "lago_coupon_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
+    "coupon_code": "code",
+    "external_customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "lago_customer_id": "99a6094e-199b-4101-896a-54e927ce7bd7",
+    "amount_cents": 123,
+    "amount_currency": "EUR",
+    "expiration_at": "2022-04-29T08:59:51Z",
+    "created_at": "2022-04-29T08:59:51Z",
+    "terminated_at": "2022-04-29T08:59:51Z",
+    "percentage_rate": null,
+    "frequency": "once",
+    "frequency_duration": null
+  }
+}

--- a/spec/fixtures/api/subscription.json
+++ b/spec/fixtures/api/subscription.json
@@ -1,0 +1,23 @@
+{
+  "subscription": {
+    "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
+    "lago_customer_id": "99a6094e-199b-4101-896a-54e927ce7bd7",
+    "external_customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "canceled_at": "2022-04-29T08:59:51Z",
+    "created_at": "2022-04-29T08:59:51Z",
+    "plan_code": "eartha lynch",
+    "started_at": "2022-04-29T08:59:51Z",
+    "ending_at": "2022-08-29T08:59:51Z",
+    "status": "active",
+    "billing_time": "anniversary",
+    "terminated_at": null,
+    "on_termination_credit_note": "skip",
+    "on_termination_invoice": "skip",
+    "subscription_at": "2022-04-29T08:59:51Z",
+    "previous_plan_code": null,
+    "next_plan_code": null,
+    "downgrade_plan_date": null,
+    "current_billing_period_started_at": "2022-04-29T08:59:51Z",
+    "current_billing_period_ending_at": "2022-05-29T23:59:59Z"
+  }
+}

--- a/spec/fixtures/api/wallet.json
+++ b/spec/fixtures/api/wallet.json
@@ -1,0 +1,38 @@
+{
+  "wallet": {
+    "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
+    "lago_customer_id": "12345",
+    "external_customer_id": "external-12345",
+    "status": "active",
+    "currency": "EUR",
+    "name": "name",
+    "rate_amount": "1.5",
+    "credits_balance": "10",
+    "balance_cents": 1000,
+    "consumed_credits": "2",
+    "created_at": "2022-04-29T08:59:51Z",
+    "expiration_at": null,
+    "last_balance_sync_at": "2022-04-29T08:59:51Z",
+    "last_consumed_credit_at": "2022-04-29T08:59:51Z",
+    "recurring_transaction_rules": [
+      {
+        "lago_id": "12345",
+        "trigger": "interval",
+        "method": "target",
+        "interval": "monthly",
+        "paid_credits": "105.0",
+        "granted_credits": "105.0",
+        "started_at": null,
+        "target_ongoing_balance": "200.0"
+      }
+    ],
+    "ongoing_balance_cents": 800,
+    "ongoing_usage_balance_cents": 200,
+    "credits_ongoing_balance": "8.0",
+    "credits_ongoing_usage_balance": "2.0",
+    "applies_to": {
+      "fee_types": ["charge"],
+      "billable_metric_codes": ["usage"]
+    }
+  }
+}

--- a/spec/lago/api/resources/customers/applied_coupon_spec.rb
+++ b/spec/lago/api/resources/customers/applied_coupon_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Lago::Api::Resources::Customers::AppliedCoupon do
+  subject(:resource) { described_class.new(client, resource_id) }
+
+  let(:client) { Lago::Api::Client.new }
+
+  let(:resource_id) { 'customer_external_id' }
+  let(:applied_coupon_response) { load_fixture('applied_coupon') }
+  let(:applied_coupon_id) { JSON.parse(applied_coupon_response)['applied_coupon']['lago_id'] }
+  let(:tax) { create(:create_tax) }
+
+  let(:error_response) do
+    {
+      'status' => 422,
+      'error' => 'Unprocessable Entity',
+      'message' => 'Validation error on the record',
+    }.to_json
+  end
+
+  describe '#get_all' do
+    let(:applied_coupons_response) do
+      {
+        'applied_coupons' => [JSON.parse(applied_coupon_response)['applied_coupon']],
+        'meta': {
+          'current_page' => 1,
+          'next_page' => 2,
+          'prev_page' => nil,
+          'total_pages' => 7,
+          'total_count' => 63,
+        },
+      }.to_json
+    end
+
+    context 'when there is no options' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/applied_coupons")
+          .to_return(body: applied_coupons_response, status: 200)
+      end
+
+      it 'returns applied_coupons on the first page' do
+        response = resource.get_all
+
+        expect(response['applied_coupons'].first['lago_id']).to eq(applied_coupon_id)
+        expect(response['applied_coupons'].first['lago_coupon_id']).to eq('b7ab2926-1de8-4428-9bcd-779314ac129b')
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when options are present' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/applied_coupons?per_page=2&page=1")
+          .to_return(body: applied_coupons_response, status: 200)
+      end
+
+      it 'returns applied_coupons on selected page' do
+        response = resource.get_all({ per_page: 2, page: 1 })
+
+        expect(response['applied_coupons'].first['lago_id']).to eq(applied_coupon_id)
+        expect(response['applied_coupons'].first['lago_coupon_id']).to eq('b7ab2926-1de8-4428-9bcd-779314ac129b')
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when there is an issue' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/applied_coupons")
+          .to_return(body: error_response, status: 404)
+      end
+
+      it 'raises an error' do
+        expect { resource.get_all }.to raise_error(Lago::Api::HttpError)
+      end
+    end
+  end
+end

--- a/spec/lago/api/resources/customers/credit_note_spec.rb
+++ b/spec/lago/api/resources/customers/credit_note_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Lago::Api::Resources::Customers::CreditNote do
+  subject(:resource) { described_class.new(client, resource_id) }
+
+  let(:client) { Lago::Api::Client.new }
+
+  let(:resource_id) { 'customer_external_id' }
+  let(:credit_note_response) { load_fixture('credit_note') }
+  let(:credit_note_id) { JSON.parse(credit_note_response)['credit_note']['lago_id'] }
+  let(:tax) { create(:create_tax) }
+
+  let(:error_response) do
+    {
+      'status' => 422,
+      'error' => 'Unprocessable Entity',
+      'message' => 'Validation error on the record',
+    }.to_json
+  end
+
+  describe '#get_all' do
+    let(:credit_notes_response) do
+      {
+        'credit_notes' => [JSON.parse(credit_note_response)['credit_note']],
+        'meta': {
+          'current_page' => 1,
+          'next_page' => 2,
+          'prev_page' => nil,
+          'total_pages' => 7,
+          'total_count' => 63,
+        },
+      }.to_json
+    end
+
+    context 'when there is no options' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/credit_notes")
+          .to_return(body: credit_notes_response, status: 200)
+      end
+
+      it 'returns credit_notes on the first page' do
+        response = resource.get_all
+
+        expect(response['credit_notes'].first['lago_id']).to eq(credit_note_id)
+        expect(response['credit_notes'].first['credit_status']).to eq('available')
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when options are present' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/credit_notes?per_page=2&page=1")
+          .to_return(body: credit_notes_response, status: 200)
+      end
+
+      it 'returns credit_notes on selected page' do
+        response = resource.get_all({ per_page: 2, page: 1 })
+
+        expect(response['credit_notes'].first['lago_id']).to eq(credit_note_id)
+        expect(response['credit_notes'].first['credit_status']).to eq('available')
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when there is an issue' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/credit_notes")
+          .to_return(body: error_response, status: 404)
+      end
+
+      it 'raises an error' do
+        expect { resource.get_all }.to raise_error(Lago::Api::HttpError)
+      end
+    end
+  end
+end

--- a/spec/lago/api/resources/customers/invoice_spec.rb
+++ b/spec/lago/api/resources/customers/invoice_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Lago::Api::Resources::Customers::Invoice do
+  subject(:resource) { described_class.new(client, resource_id) }
+
+  let(:client) { Lago::Api::Client.new }
+
+  let(:resource_id) { 'customer_external_id' }
+  let(:invoice_response) { load_fixture('invoice') }
+  let(:invoice_id) { JSON.parse(invoice_response)['invoice']['lago_id'] }
+  let(:tax) { create(:create_tax) }
+
+  let(:error_response) do
+    {
+      'status' => 422,
+      'error' => 'Unprocessable Entity',
+      'message' => 'Validation error on the record',
+    }.to_json
+  end
+
+  describe '#get_all' do
+    let(:invoices_response) do
+      {
+        'invoices' => [JSON.parse(invoice_response)['invoice']],
+        'meta': {
+          'current_page' => 1,
+          'next_page' => 2,
+          'prev_page' => nil,
+          'total_pages' => 7,
+          'total_count' => 63,
+        },
+      }.to_json
+    end
+
+    context 'when there is no options' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/invoices")
+          .to_return(body: invoices_response, status: 200)
+      end
+
+      it 'returns invoices on the first page' do
+        response = resource.get_all
+
+        expect(response['invoices'].first['lago_id']).to eq(invoice_id)
+        expect(response['invoices'].first['payment_status']).to eq('succeeded')
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when options are present' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/invoices?per_page=2&page=1")
+          .to_return(body: invoices_response, status: 200)
+      end
+
+      it 'returns invoices on selected page' do
+        response = resource.get_all({ per_page: 2, page: 1 })
+
+        expect(response['invoices'].first['lago_id']).to eq(invoice_id)
+        expect(response['invoices'].first['payment_status']).to eq('succeeded')
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when there is an issue' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/invoices")
+          .to_return(body: error_response, status: 404)
+      end
+
+      it 'raises an error' do
+        expect { resource.get_all }.to raise_error(Lago::Api::HttpError)
+      end
+    end
+  end
+end

--- a/spec/lago/api/resources/customers/payment_request_spec.rb
+++ b/spec/lago/api/resources/customers/payment_request_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Lago::Api::Resources::Customers::PaymentRequest do
+  subject(:resource) { described_class.new(client, resource_id) }
+
+  let(:client) { Lago::Api::Client.new }
+
+  let(:resource_id) { 'customer_external_id' }
+  let(:payment_request_response) { load_fixture('payment_request') }
+  let(:payment_request_id) { JSON.parse(payment_request_response)['payment_request']['lago_id'] }
+  let(:tax) { create(:create_tax) }
+
+  let(:error_response) do
+    {
+      'status' => 422,
+      'error' => 'Unprocessable Entity',
+      'message' => 'Validation error on the record',
+    }.to_json
+  end
+
+  describe '#get_all' do
+    let(:payment_requests_response) do
+      {
+        'payment_requests' => [JSON.parse(payment_request_response)['payment_request']],
+        'meta': {
+          'current_page' => 1,
+          'next_page' => 2,
+          'prev_page' => nil,
+          'total_pages' => 7,
+          'total_count' => 63,
+        },
+      }.to_json
+    end
+
+    context 'when there is no options' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/payment_requests")
+          .to_return(body: payment_requests_response, status: 200)
+      end
+
+      it 'returns payment_requests on the first page' do
+        response = resource.get_all
+
+        expect(response['payment_requests'].first['lago_id']).to eq(payment_request_id)
+        expect(response['payment_requests'].first['payment_status']).to eq('pending')
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when options are present' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/payment_requests?per_page=2&page=1")
+          .to_return(body: payment_requests_response, status: 200)
+      end
+
+      it 'returns payment_requests on selected page' do
+        response = resource.get_all({ per_page: 2, page: 1 })
+
+        expect(response['payment_requests'].first['lago_id']).to eq(payment_request_id)
+        expect(response['payment_requests'].first['payment_status']).to eq('pending')
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when there is an issue' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/payment_requests")
+          .to_return(body: error_response, status: 404)
+      end
+
+      it 'raises an error' do
+        expect { resource.get_all }.to raise_error(Lago::Api::HttpError)
+      end
+    end
+  end
+end

--- a/spec/lago/api/resources/customers/payment_spec.rb
+++ b/spec/lago/api/resources/customers/payment_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Lago::Api::Resources::Customers::Payment do
+  subject(:resource) { described_class.new(client, resource_id) }
+
+  let(:client) { Lago::Api::Client.new }
+
+  let(:resource_id) { 'customer_external_id' }
+  let(:payment_response) { load_fixture('payment') }
+  let(:payment_id) { JSON.parse(payment_response)['payment']['lago_id'] }
+  let(:tax) { create(:create_tax) }
+
+  let(:error_response) do
+    {
+      'status' => 422,
+      'error' => 'Unprocessable Entity',
+      'message' => 'Validation error on the record',
+    }.to_json
+  end
+
+  describe '#get_all' do
+    let(:payments_response) do
+      {
+        'payments' => [JSON.parse(payment_response)['payment']],
+        'meta': {
+          'current_page' => 1,
+          'next_page' => 2,
+          'prev_page' => nil,
+          'total_pages' => 7,
+          'total_count' => 63,
+        },
+      }.to_json
+    end
+
+    context 'when there is no options' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/payments")
+          .to_return(body: payments_response, status: 200)
+      end
+
+      it 'returns payments on the first page' do
+        response = resource.get_all
+
+        expect(response['payments'].first['lago_id']).to eq(payment_id)
+        expect(response['payments'].first['payment_status']).to eq('succeeded')
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when options are present' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/payments?per_page=2&page=1")
+          .to_return(body: payments_response, status: 200)
+      end
+
+      it 'returns payments on selected page' do
+        response = resource.get_all({ per_page: 2, page: 1 })
+
+        expect(response['payments'].first['lago_id']).to eq(payment_id)
+        expect(response['payments'].first['payment_status']).to eq('succeeded')
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when there is an issue' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/payments")
+          .to_return(body: error_response, status: 404)
+      end
+
+      it 'raises an error' do
+        expect { resource.get_all }.to raise_error(Lago::Api::HttpError)
+      end
+    end
+  end
+end

--- a/spec/lago/api/resources/customers/subscription_spec.rb
+++ b/spec/lago/api/resources/customers/subscription_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Lago::Api::Resources::Customers::Subscription do
+  subject(:resource) { described_class.new(client, resource_id) }
+
+  let(:client) { Lago::Api::Client.new }
+
+  let(:resource_id) { 'customer_external_id' }
+  let(:subscription_response) { load_fixture('subscription') }
+  let(:subscription_id) { JSON.parse(subscription_response)['subscription']['lago_id'] }
+  let(:tax) { create(:create_tax) }
+
+  let(:error_response) do
+    {
+      'status' => 422,
+      'error' => 'Unprocessable Entity',
+      'message' => 'Validation error on the record',
+    }.to_json
+  end
+
+  describe '#get_all' do
+    let(:subscriptions_response) do
+      {
+        'subscriptions' => [JSON.parse(subscription_response)['subscription']],
+        'meta': {
+          'current_page' => 1,
+          'next_page' => 2,
+          'prev_page' => nil,
+          'total_pages' => 7,
+          'total_count' => 63,
+        },
+      }.to_json
+    end
+
+    context 'when there is no options' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/subscriptions")
+          .to_return(body: subscriptions_response, status: 200)
+      end
+
+      it 'returns subscriptions on the first page' do
+        response = resource.get_all
+
+        expect(response['subscriptions'].first['lago_id']).to eq(subscription_id)
+        expect(response['subscriptions'].first['status']).to eq('active')
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when options are present' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/subscriptions?per_page=2&page=1")
+          .to_return(body: subscriptions_response, status: 200)
+      end
+
+      it 'returns subscriptions on selected page' do
+        response = resource.get_all({ per_page: 2, page: 1 })
+
+        expect(response['subscriptions'].first['lago_id']).to eq(subscription_id)
+        expect(response['subscriptions'].first['status']).to eq('active')
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when there is an issue' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/subscriptions")
+          .to_return(body: error_response, status: 404)
+      end
+
+      it 'raises an error' do
+        expect { resource.get_all }.to raise_error(Lago::Api::HttpError)
+      end
+    end
+  end
+end

--- a/spec/lago/api/resources/customers/wallet_spec.rb
+++ b/spec/lago/api/resources/customers/wallet_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Lago::Api::Resources::Customers::Wallet do
+  subject(:resource) { described_class.new(client, resource_id) }
+
+  let(:client) { Lago::Api::Client.new }
+
+  let(:resource_id) { 'customer_external_id' }
+  let(:wallet_response) { load_fixture('wallet') }
+  let(:wallet_id) { JSON.parse(wallet_response)['wallet']['lago_id'] }
+  let(:tax) { create(:create_tax) }
+
+  let(:error_response) do
+    {
+      'status' => 422,
+      'error' => 'Unprocessable Entity',
+      'message' => 'Validation error on the record',
+    }.to_json
+  end
+
+  describe '#get_all' do
+    let(:wallets_response) do
+      {
+        'wallets' => [JSON.parse(wallet_response)['wallet']],
+        'meta': {
+          'current_page' => 1,
+          'next_page' => 2,
+          'prev_page' => nil,
+          'total_pages' => 7,
+          'total_count' => 63,
+        },
+      }.to_json
+    end
+
+    context 'when there is no options' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/wallets")
+          .to_return(body: wallets_response, status: 200)
+      end
+
+      it 'returns wallets on the first page' do
+        response = resource.get_all
+
+        expect(response['wallets'].first['lago_id']).to eq(wallet_id)
+        expect(response['wallets'].first['status']).to eq('active')
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when options are present' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/wallets?per_page=2&page=1")
+          .to_return(body: wallets_response, status: 200)
+      end
+
+      it 'returns wallets on selected page' do
+        response = resource.get_all({ per_page: 2, page: 1 })
+
+        expect(response['wallets'].first['lago_id']).to eq(wallet_id)
+        expect(response['wallets'].first['status']).to eq('active')
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when there is an issue' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{resource_id}/wallets")
+          .to_return(body: error_response, status: 404)
+      end
+
+      it 'raises an error' do
+        expect { resource.get_all }.to raise_error(Lago::Api::HttpError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR follows a critical issue on the `GET /api/v1/invoices` when requests were filtered by `external_customer_id` from the GO SDK client. See https://github.com/getlago/lago-go-client/pull/288

A new set of endpoints have been added to retrieve resources scoped to a specific customer.

## Description

This PR adds the clients for all the newly created routes:
- `/api/v1/customers/:customer_external_id/applied_coupons`
- `/api/v1/customers/:customer_external_id/credit_notes`
- `/api/v1/customers/:customer_external_id/invoices`
- `/api/v1/customers/:customer_external_id/payment_requests`
- `/api/v1/customers/:customer_external_id/payments`
- `/api/v1/customers/:customer_external_id/subscriptions`
- `/api/v1/customers/:customer_external_id/wallets`

Related to:
- https://github.com/getlago/lago-api/pull/4290
- https://github.com/getlago/lago-api/pull/4293
- https://github.com/getlago/lago-api/pull/4294
- https://github.com/getlago/lago-api/pull/4295
- https://github.com/getlago/lago-api/pull/4297
- https://github.com/getlago/lago-api/pull/4298
- https://github.com/getlago/lago-api/pull/4299
- https://github.com/getlago/lago-openapi/pull/448