### PR TITLE
feat(wallet): Allow to set the name of a wallet's initial transactions

### DIFF
--- a/lib/lago/api/resources/wallet.rb
+++ b/lib/lago/api/resources/wallet.rb
@@ -15,23 +15,24 @@ module Lago
         end
 
         def whitelist_params(params)
-          result_hash = {
-            external_customer_id: params[:external_customer_id],
-            rate_amount: params[:rate_amount],
-            name: params[:name],
-            paid_credits: params[:paid_credits],
-            granted_credits: params[:granted_credits],
-            currency: params[:currency],
-            expiration_at: params[:expiration_at],
-            transaction_metadata: params[:transaction_metadata],
-            invoice_requires_successful_payment: params[:invoice_requires_successful_payment],
-          }.compact
+          result_hash = params.compact.slice(
+            :external_customer_id,
+            :rate_amount,
+            :name,
+            :paid_credits,
+            :granted_credits,
+            :currency,
+            :expiration_at,
+            :transaction_metadata,
+            :invoice_requires_successful_payment,
+            :transaction_name,
+          )
 
           recurring_rules = whitelist_recurring_rules(params[:recurring_transaction_rules])
-          result_hash[:recurring_transaction_rules] = recurring_rules unless recurring_rules.empty?
+          result_hash[:recurring_transaction_rules] = recurring_rules if recurring_rules.any?
 
           applies_to = whitelist_applies_to(params[:applies_to])
-          result_hash[:applies_to] = applies_to unless applies_to.empty?
+          result_hash[:applies_to] = applies_to if applies_to.any?
 
           { root_name => result_hash }
         end

--- a/spec/lago/api/resources/wallet_spec.rb
+++ b/spec/lago/api/resources/wallet_spec.rb
@@ -31,7 +31,12 @@ RSpec.describe Lago::Api::Resources::Wallet do
   end
 
   describe '#create' do
-    let(:params) { factory_wallet.to_h }
+    let(:params) do
+      factory_wallet.to_h.merge(
+        transaction_name: 'wallet transaction name',
+        transaction_metadata: [{ 'key' => 'key', 'value' => 'value' }]
+      )
+    end
     let(:body) do
       {
         'wallet' => {
@@ -41,6 +46,8 @@ RSpec.describe Lago::Api::Resources::Wallet do
           'paid_credits' => '100',
           'granted_credits' => '100',
           'expiration_at' => '2022-07-07T23:59:59Z',
+          'transaction_name' => 'wallet transaction name',
+          'transaction_metadata' => [{ 'key' => 'key', 'value' => 'value' }],
           'recurring_transaction_rules' => [
             {
               'paid_credits' => '105',


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-the-name-of-a-wallet-transaction-at-top-up

## Context

Follow up of https://github.com/getlago/lago-api/pull/4327.

## Description

This allows to provide a `name` for the wallet transactions created when creating a wallet via the `transaction_name` field.