### PR TITLE
Add lago_invoice_id to wallet transaction specs

### DIFF
--- a/spec/lago/api/resources/wallet_transaction_spec.rb
+++ b/spec/lago/api/resources/wallet_transaction_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Lago::Api::Resources::WalletTransaction do
         {
           'lago_id' => 'this-is-lago-id',
           'lago_wallet_id' => factory_wallet_transaction.wallet_id,
+          'lago_invoice_id' => 'invoice-uuid-1111',
           'amount' => factory_wallet_transaction.paid_credits,
           'name' => factory_wallet_transaction.name,
           'status' => 'pending',
@@ -25,6 +26,7 @@ RSpec.describe Lago::Api::Resources::WalletTransaction do
         {
           'lago_id' => 'this-is-lago-id2',
           'lago_wallet_id' => factory_wallet_transaction.wallet_id,
+          'lago_invoice_id' => nil,
           'amount' => factory_wallet_transaction.granted_credits,
           'name' => factory_wallet_transaction.name,
           'status' => 'settled',
@@ -80,6 +82,8 @@ RSpec.describe Lago::Api::Resources::WalletTransaction do
 
         expect(wallet_transactions.first.lago_id).to eq('this-is-lago-id')
         expect(wallet_transactions.last.lago_id).to eq('this-is-lago-id2')
+        expect(wallet_transactions.first.lago_invoice_id).to eq('invoice-uuid-1111')
+        expect(wallet_transactions.last.lago_invoice_id).to be_nil
         expect(wallet_transactions).to all(have_attributes(name: 'Transaction Name'))
       end
     end
@@ -131,6 +135,7 @@ RSpec.describe Lago::Api::Resources::WalletTransaction do
             {
               'lago_id' => 'this-is-lago-id',
               'lago_wallet_id' => factory_wallet_transaction.wallet_id,
+              'lago_invoice_id' => 'invoice-uuid-1111',
               'amount' => factory_wallet_transaction.paid_credits,
               'name' => factory_wallet_transaction.name,
               'status' => 'pending',


### PR DESCRIPTION
### Summary

Adds lago_invoice_id to the wallet transaction spec response fixtures and assertions, enabling validation that wallet transactions can be traced back to the invoice that triggered them.

### Changes

spec/lago/api/resources/wallet_transaction_spec.rb — Added lago_invoice_id to mock response hashes and added assertions verifying it's correctly parsed (including nil case)