### PR TITLE
fix: add billable_metric_code to alert create and batch input

### DIFF
--- a/lib/lago/api/resources/customers/wallets/alert.rb
+++ b/lib/lago/api/resources/customers/wallets/alert.rb
@@ -43,6 +43,7 @@ module Lago
                 alert: {
                   name: params[:name],
                   code: params[:code],
+                  billable_metric_code: params[:billable_metric_code],
                   thresholds: params[:thresholds],
                 }.compact,
               }
@@ -59,6 +60,7 @@ module Lago
                 alert_type: params[:alert_type],
                 name: params[:name],
                 code: params[:code],
+                billable_metric_code: params[:billable_metric_code],
                 thresholds: params[:thresholds],
               }.compact
             end

--- a/spec/fixtures/api/wallet_alert.json
+++ b/spec/fixtures/api/wallet_alert.json
@@ -1,8 +1,9 @@
 {
   "alert": {
     "external_customer_id": "customer-id-12345",
-    "code": "wallet_balance_alert",
-    "alert_type": "wallet_balance_amount",
+    "code": "usage_alert",
+    "alert_type": "billable_metric_current_usage_amount",
+    "billable_metric_code": "storage",
     "thresholds": [
       {
         "code": "warn",

--- a/spec/lago/api/resources/customers/wallets/alerts_spec.rb
+++ b/spec/lago/api/resources/customers/wallets/alerts_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Lago::Api::Resources::Customers::Wallets::Alert do
         :name,
         :code,
         :alert_type,
+        :billable_metric_code,
         :thresholds,
       )
     end
@@ -103,7 +104,7 @@ RSpec.describe Lago::Api::Resources::Customers::Wallets::Alert do
 
   describe '#update' do
     let(:params) do
-      { name: 'Update name' }
+      { name: 'Update name', billable_metric_code: 'storage' }
     end
     let(:json_response) { load_fixture('wallet_alert') }
     let(:alert_response) { JSON.parse(json_response) }
@@ -247,9 +248,10 @@ RSpec.describe Lago::Api::Resources::Customers::Wallets::Alert do
           thresholds: [{ code: 'warn', value: 1000 }],
         },
         {
-          code: 'wallet_credits_alert',
-          name: 'Wallet Credits Alert',
-          alert_type: 'wallet_credits_balance',
+          code: 'usage_alert',
+          name: 'Usage Alert',
+          alert_type: 'billable_metric_current_usage_amount',
+          billable_metric_code: 'storage',
           thresholds: [{ value: 2000 }],
         },
       ]


### PR DESCRIPTION
Implements API changes in getlago/lago-openapi#525

Wires `billable_metric_code` through wallet alert `create`, `update`,
and `batch create`. Switches the `wallet_alert` fixture and batch
test entry to the metric-bound shape so the updated spec still makes sense product-wise.