### PR TITLE
fix(api): Deprecate filter_by prefixed params on current usage

### DIFF
--- a/lib/lago/api/resources/customer.rb
+++ b/lib/lago/api/resources/customer.rb
@@ -20,10 +20,15 @@ module Lago
 
         def current_usage( # rubocop:disable Metrics/ParameterLists
           external_customer_id, external_subscription_id, apply_taxes: nil,
+          charge_id: nil, charge_code: nil, billable_metric_code: nil, group: nil,
           filter_by_charge_id: nil, filter_by_charge_code: nil, filter_by_group: nil, full_usage: nil
         )
           query_params = { external_subscription_id: external_subscription_id }
           query_params[:apply_taxes] = apply_taxes unless apply_taxes.nil?
+          query_params[:charge_id] = charge_id unless charge_id.nil?
+          query_params[:charge_code] = charge_code unless charge_code.nil?
+          query_params[:billable_metric_code] = billable_metric_code unless billable_metric_code.nil?
+          group&.each { |k, v| query_params[:"group[#{k}]"] = v }
           query_params[:filter_by_charge_id] = filter_by_charge_id unless filter_by_charge_id.nil?
           query_params[:filter_by_charge_code] = filter_by_charge_code unless filter_by_charge_code.nil?
           filter_by_group&.each { |k, v| query_params[:"filter_by_group[#{k}]"] = v }

--- a/spec/lago/api/resources/customer_spec.rb
+++ b/spec/lago/api/resources/customer_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Lago::Api::Resources::Customer do
       end
     end
 
-    context 'when filter parameters are provided' do
+    context 'when filter parameters are provided (deprecated filter_by_* names)' do
       let(:charge_id) { '1a901a90-1a90-1a90-1a90-1a901a901a90' }
 
       before do
@@ -123,6 +123,34 @@ RSpec.describe Lago::Api::Resources::Customer do
           subscription_external_id,
           filter_by_charge_code: 'storage',
           filter_by_group: { cloud: 'aws' },
+          full_usage: 'true',
+        )
+        expect(response['customer_usage']['from_datetime']).to eq('2022-07-01T00:00:00Z')
+      end
+    end
+
+    context 'when new unprefixed filter parameters are provided' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{customer_external_id}/current_usage")
+          .with(query: {
+            external_subscription_id: subscription_external_id,
+            charge_id: '1a901a90-1a90-1a90-1a90-1a901a901a90',
+            charge_code: 'storage',
+            billable_metric_code: 'storage',
+            'group[cloud]' => 'aws',
+            full_usage: 'true',
+          })
+          .to_return(body: customer_usage_response, status: 200)
+      end
+
+      it 'returns the usage of the customer with new filters applied' do
+        response = resource.current_usage(
+          customer_external_id,
+          subscription_external_id,
+          charge_id: '1a901a90-1a90-1a90-1a90-1a901a901a90',
+          charge_code: 'storage',
+          billable_metric_code: 'storage',
+          group: { cloud: 'aws' },
           full_usage: 'true',
         )
         expect(response['customer_usage']['from_datetime']).to eq('2022-07-01T00:00:00Z')


### PR DESCRIPTION
## Context

We have different param naming convention in the `current_usage` endpoint. Some have the prefix `filter_by_`, not reflecting the pattern on the rest of the API. Add support for conventional ones, and mark the prefixed ones as deprecated.

## Description

Introduce unprefixed aliases for the `filter_by_*` query parameters on the `GET /customers/:customer_id/current_usage` endpoint (`charge_id, charge_code, billable_metric_code, group`), consistent with the naming convention used across the rest of the API.

The old `filter_by_*` names remain supported for backward compatibility.
