### PR TITLE
feat(clickhouse): Add organization.events_store attribute [ING-205]

### DIFF
--- a/spec/fixtures/api/organization.json
+++ b/spec/fixtures/api/organization.json
@@ -3,9 +3,7 @@
     "name": "Hooli",
     "created_at": "2022-05-02T13:04:09Z",
     "webhook_url": "https://test-example.example",
-    "webhook_urls": [
-      "https://test-example.example"
-    ],
+    "webhook_urls": ["https://test-example.example"],
     "country": null,
     "default_currency": "USD",
     "address_line1": null,
@@ -27,6 +25,7 @@
       "invoice_grace_period": 3,
       "document_locale": "fr"
     },
+    "events_store": "clickhouse",
     "taxes": [
       {
         "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",

--- a/spec/lago/api/resources/organization_spec.rb
+++ b/spec/lago/api/resources/organization_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Lago::Api::Resources::Organization do
         expect(organization.document_number_prefix).to eq('ORG-1234')
         expect(organization.tax_identification_number).to eq('EU123456789')
         expect(organization.billing_configuration.invoice_grace_period).to eq(3)
+        expect(organization.events_store).to eq('clickhouse')
       end
     end
 


### PR DESCRIPTION
Related to https://github.com/getlago/lago-api/pull/5566

The PR documents the new `events_store` attribute on the organization object