### PR TITLE
[ING-30] test: Cover currency filter on list endpoints

### DIFF
--- a/spec/lago/api/resources/payment_request_spec.rb
+++ b/spec/lago/api/resources/payment_request_spec.rb
@@ -112,6 +112,20 @@ RSpec.describe Lago::Api::Resources::PaymentRequest do
           end
         end
 
+        context 'when currency is given' do
+          before do
+            stub_request(:get, 'https://api.getlago.com/api/v1/payment_requests?currency=EUR')
+              .to_return(body: payment_requests_response, status: 200)
+          end
+
+          it 'returns payment requests filtered by currency' do
+            response = resource.get_all({ currency: 'EUR' })
+
+            expect(response['payment_requests'].first['lago_id']).to eq(payment_request_id)
+            expect(response['meta']['current_page']).to eq(1)
+          end
+        end
+
         context 'when there is an issue' do
           before do
             stub_request(:get, 'https://api.getlago.com/api/v1/payment_requests')

--- a/spec/lago/api/resources/subscription_spec.rb
+++ b/spec/lago/api/resources/subscription_spec.rb
@@ -451,6 +451,20 @@ RSpec.describe Lago::Api::Resources::Subscription do
       end
     end
 
+    context 'when currency is given' do
+      before do
+        stub_request(:get, 'https://api.getlago.com/api/v1/subscriptions?currency=EUR')
+          .to_return(body: response, status: 200)
+      end
+
+      it 'returns subscriptions filtered by currency' do
+        response = resource.get_all({ currency: 'EUR' })
+
+        expect(response['subscriptions'].first['lago_id']).to eq(factory_subscription.lago_id)
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
     context 'when status is given' do
       before do
         stub_request(:get, 'https://api.getlago.com/api/v1/subscriptions?external_customer_id=123&status%5B%5D=pending')

--- a/spec/lago/api/resources/wallet_spec.rb
+++ b/spec/lago/api/resources/wallet_spec.rb
@@ -727,6 +727,20 @@ RSpec.describe Lago::Api::Resources::Wallet do
       end
     end
 
+    context 'when currency is given' do
+      before do
+        stub_request(:get, 'https://api.getlago.com/api/v1/wallets?currency=EUR')
+          .to_return(body: response, status: 200)
+      end
+
+      it 'returns wallets filtered by currency' do
+        response = resource.get_all({ currency: 'EUR' })
+
+        expect(response['wallets'].first['lago_id']).to eq('this-is-lago-id')
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
     context 'when there is an issue' do
       before do
         stub_request(:get, 'https://api.getlago.com/api/v1/wallets')


### PR DESCRIPTION
## Context

The lago-api backend exposes an optional `currency` query parameter on the subscriptions, wallets, and payment_requests list endpoints (getlago/lago-api#5249). The Ruby client's `get_all(options = {})` already forwards arbitrary options as query parameters, so no source change is required, but the behavior was untested.

## Description

Adds a `when currency is given` example to the `#get_all` specs of the subscription, wallet, and payment_request resources. Each stubs the request with the `currency` query string, so the example fails (WebMock raises on an unmatched request) if the option is not forwarded.

## How to try locally

```
bundle install
bundle exec rspec spec/lago/api/resources/subscription_spec.rb spec/lago/api/resources/wallet_spec.rb spec/lago/api/resources/payment_request_spec.rb
```