### PR TITLE
feat(presentation_group_keys): Support presentation group keys feature

### DIFF
--- a/lib/lago/api/resources/customer.rb
+++ b/lib/lago/api/resources/customer.rb
@@ -21,7 +21,8 @@ module Lago
         def current_usage( # rubocop:disable Metrics/ParameterLists
           external_customer_id, external_subscription_id, apply_taxes: nil,
           charge_id: nil, charge_code: nil, billable_metric_code: nil, group: nil,
-          filter_by_charge_id: nil, filter_by_charge_code: nil, filter_by_group: nil, full_usage: nil
+          filter_by_charge_id: nil, filter_by_charge_code: nil, filter_by_group: nil, full_usage: nil,
+          filter_by_presentation: nil
         )
           query_params = { external_subscription_id: external_subscription_id }
           query_params[:apply_taxes] = apply_taxes unless apply_taxes.nil?
@@ -33,6 +34,10 @@ module Lago
           query_params[:filter_by_charge_code] = filter_by_charge_code unless filter_by_charge_code.nil?
           filter_by_group&.each { |k, v| query_params[:"filter_by_group[#{k}]"] = v }
           query_params[:full_usage] = full_usage unless full_usage.nil?
+          unless filter_by_presentation.nil?
+            query_params[:filter_by_presentation] =
+              filter_by_presentation_param(filter_by_presentation)
+          end
           query_string = URI.encode_www_form(query_params)
 
           uri = URI("#{client.base_api_url}#{api_resource}/#{external_customer_id}/current_usage?#{query_string}")
@@ -124,6 +129,10 @@ module Lago
           result_hash[:metadata] = metadata unless metadata.empty?
 
           { root_name => result_hash }
+        end
+
+        def filter_by_presentation_param(filter_by_presentation)
+          filter_by_presentation.is_a?(String) ? filter_by_presentation : JSON.generate(filter_by_presentation)
         end
 
         def whitelist_billing_configuration(billing_params)

--- a/spec/factories/plan.rb
+++ b/spec/factories/plan.rb
@@ -24,7 +24,12 @@ FactoryBot.define do
           invoice_display_name: 'Charge 1',
           min_amount_cents: 0,
           accepts_target_wallet: false,
-          properties: { amount: '0.22' },
+          properties: {
+            amount: '0.22',
+            presentation_group_keys: [
+              { value: 'region', options: { display_in_invoice: true } },
+            ],
+          },
         },
       ]
     end

--- a/spec/fixtures/api/customer_projected_usage.json
+++ b/spec/fixtures/api/customer_projected_usage.json
@@ -3,16 +3,20 @@
     "from_datetime": "2022-07-01T00:00:00Z",
     "to_datetime": "2022-07-31T23:59:59Z",
     "issuing_date": "2022-08-01",
-    "invoice_id": null,
     "currency": "EUR",
     "amount_cents": 123,
+    "projected_amount_cents": 246,
     "total_amount_cents": 123,
+    "projected_total_amount_cents": 246,
     "taxes_amount_cents": 0,
+    "projected_taxes_amount_cents": 0,
     "charges_usage": [
       {
         "units": "1.0",
+        "projected_units": "2.0",
         "events_count": 1,
         "amount_cents": 123,
+        "projected_amount_cents": 246,
         "amount_currency": "EUR",
         "charge": {
           "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
@@ -28,12 +32,12 @@
         "filters": [
           {
             "units": "3.0",
+            "projected_units": "6.0",
             "events_count": 1,
             "amount_cents": 123,
+            "projected_amount_cents": 246,
             "values": {
-              "country": [
-                "france"
-              ]
+              "country": ["france"]
             },
             "presentation_breakdowns": [
               {
@@ -41,6 +45,14 @@
                   "team": "engineering"
                 },
                 "units": "2.0"
+              }
+            ],
+            "projected_presentation_breakdowns": [
+              {
+                "presentation_by": {
+                  "team": "engineering"
+                },
+                "units": "4.0"
               }
             ]
           }
@@ -53,23 +65,33 @@
             "units": "2.0"
           }
         ],
+        "projected_presentation_breakdowns": [
+          {
+            "presentation_by": {
+              "team": "engineering"
+            },
+            "units": "4.0"
+          }
+        ],
         "grouped_usage": [
           {
             "amount_cents": 123,
+            "projected_amount_cents": 246,
             "events_count": 1,
             "units": "3.0",
+            "projected_units": "6.0",
             "grouped_by": {
               "agent_name": "aragorn"
             },
             "filters": [
               {
                 "units": "3.0",
+                "projected_units": "6.0",
                 "events_count": 1,
                 "amount_cents": 123,
+                "projected_amount_cents": 246,
                 "values": {
-                  "country": [
-                    "france"
-                  ]
+                  "country": ["france"]
                 },
                 "presentation_breakdowns": [
                   {
@@ -77,6 +99,14 @@
                       "team": "engineering"
                     },
                     "units": "2.0"
+                  }
+                ],
+                "projected_presentation_breakdowns": [
+                  {
+                    "presentation_by": {
+                      "team": "engineering"
+                    },
+                    "units": "4.0"
                   }
                 ]
               }
@@ -87,6 +117,14 @@
                   "team": "engineering"
                 },
                 "units": "2.0"
+              }
+            ],
+            "projected_presentation_breakdowns": [
+              {
+                "presentation_by": {
+                  "team": "engineering"
+                },
+                "units": "4.0"
               }
             ]
           }

--- a/spec/fixtures/api/fee.json
+++ b/spec/fixtures/api/fee.json
@@ -25,6 +25,14 @@
     "total_amount_currency": "EUR",
     "units": "10.0",
     "events_count": 10,
+    "presentation_breakdowns": [
+      {
+        "presentation_by": {
+          "team": "engineering"
+        },
+        "units": "2.0"
+      }
+    ],
     "applied_taxes": [
       {
         "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",

--- a/spec/fixtures/api/plan.json
+++ b/spec/fixtures/api/plan.json
@@ -28,7 +28,15 @@
         "min_amount_cents": 0,
         "properties": {
           "amount": "0.22",
-          "pricing_group_keys": ["agent_name"]
+          "pricing_group_keys": ["agent_name"],
+          "presentation_group_keys": [
+            {
+              "value": "region",
+              "options": {
+                "display_in_invoice": true
+              }
+            }
+          ]
         },
         "filters": [
           {

--- a/spec/fixtures/api/plan_charge.json
+++ b/spec/fixtures/api/plan_charge.json
@@ -12,7 +12,15 @@
     "min_amount_cents": 0,
     "prorated": false,
     "properties": {
-      "amount": "0.22"
+      "amount": "0.22",
+      "presentation_group_keys": [
+        {
+          "value": "region",
+          "options": {
+            "display_in_invoice": true
+          }
+        }
+      ]
     },
     "filters": [],
     "taxes": [],

--- a/spec/fixtures/api/plan_charges.json
+++ b/spec/fixtures/api/plan_charges.json
@@ -13,7 +13,15 @@
       "min_amount_cents": 0,
       "prorated": false,
       "properties": {
-        "amount": "0.22"
+        "amount": "0.22",
+        "presentation_group_keys": [
+          {
+            "value": "region",
+            "options": {
+              "display_in_invoice": true
+            }
+          }
+        ]
       },
       "filters": [],
       "taxes": [],

--- a/spec/fixtures/api/plans.json
+++ b/spec/fixtures/api/plans.json
@@ -29,7 +29,15 @@
           "accepts_target_wallet": false,
           "properties": {
             "amount": "0.22",
-            "pricing_group_keys": ["agent_name"]
+            "pricing_group_keys": ["agent_name"],
+            "presentation_group_keys": [
+              {
+                "value": "region",
+                "options": {
+                  "display_in_invoice": true
+                }
+              }
+            ]
           },
           "filters": [
             {

--- a/spec/fixtures/api/subscription_charge.json
+++ b/spec/fixtures/api/subscription_charge.json
@@ -12,7 +12,15 @@
     "min_amount_cents": 0,
     "prorated": false,
     "properties": {
-      "amount": "0.22"
+      "amount": "0.22",
+      "presentation_group_keys": [
+        {
+          "value": "region",
+          "options": {
+            "display_in_invoice": true
+          }
+        }
+      ]
     },
     "filters": [],
     "taxes": [],

--- a/spec/fixtures/api/subscription_charges.json
+++ b/spec/fixtures/api/subscription_charges.json
@@ -13,7 +13,15 @@
       "min_amount_cents": 0,
       "prorated": false,
       "properties": {
-        "amount": "0.22"
+        "amount": "0.22",
+        "presentation_group_keys": [
+          {
+            "value": "region",
+            "options": {
+              "display_in_invoice": true
+            }
+          }
+        ]
       },
       "filters": [],
       "taxes": [],

--- a/spec/lago/api/resources/customer_spec.rb
+++ b/spec/lago/api/resources/customer_spec.rb
@@ -157,6 +157,71 @@ RSpec.describe Lago::Api::Resources::Customer do
       end
     end
 
+    context 'when filter_by_presentation parameter is provided' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{customer_external_id}/current_usage")
+          .with(query: {
+            external_subscription_id: subscription_external_id,
+            filter_by_presentation: '["engineering","operations"]',
+          })
+          .to_return(body: customer_usage_response, status: 200)
+      end
+
+      it 'returns the usage of the customer with presentation breakdowns filtered' do
+        response = resource.current_usage(
+          customer_external_id,
+          subscription_external_id,
+          filter_by_presentation: %w[engineering operations],
+        )
+
+        breakdown = response['customer_usage']['charges_usage'].first['presentation_breakdowns'].first
+        expect(breakdown['presentation_by']).to eq('team' => 'engineering')
+        expect(breakdown['units']).to eq('2.0')
+      end
+    end
+
+    context 'when filter_by_presentation is empty' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{customer_external_id}/current_usage")
+          .with(query: {
+            external_subscription_id: subscription_external_id,
+            filter_by_presentation: '[]',
+          })
+          .to_return(body: customer_usage_response, status: 200)
+      end
+
+      it 'passes an empty presentation filter' do
+        response = resource.current_usage(
+          customer_external_id,
+          subscription_external_id,
+          filter_by_presentation: [],
+        )
+
+        expect(response['customer_usage']['from_datetime']).to eq('2022-07-01T00:00:00Z')
+      end
+    end
+
+    context 'when filter_by_presentation is already JSON encoded' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{customer_external_id}/current_usage")
+          .with(query: {
+            external_subscription_id: subscription_external_id,
+            filter_by_presentation: '["engineering","operations"]',
+          })
+          .to_return(body: customer_usage_response, status: 200)
+      end
+
+      it 'passes the encoded presentation filter through' do
+        response = resource.current_usage(
+          customer_external_id,
+          subscription_external_id,
+          filter_by_presentation: '["engineering","operations"]',
+        )
+
+        expect(response['customer_usage']['from_datetime']).to eq('2022-07-01T00:00:00Z')
+      end
+    end
+
     context 'when the customer does not exists' do
       let(:customer_external_id) { 'DOESNOTEXIST' }
 
@@ -182,6 +247,26 @@ RSpec.describe Lago::Api::Resources::Customer do
         expect do
           resource.current_usage(customer_external_id, subscription_external_id)
         end.to raise_error(Lago::Api::HttpError)
+      end
+    end
+  end
+
+  describe '#projected_usage' do
+    let(:customer_usage_response) { load_fixture('customer_projected_usage') }
+    let(:subscription_external_id) { '123' }
+
+    context 'when the customer exists' do
+      before do
+        stub_request(:get, "https://api.getlago.com/api/v1/customers/#{customer_external_id}/projected_usage?external_subscription_id=#{subscription_external_id}")
+          .to_return(body: customer_usage_response, status: 200)
+      end
+
+      it 'returns projected presentation breakdowns' do
+        response = resource.projected_usage(customer_external_id, subscription_external_id)
+        charge_usage = response['customer_usage']['charges_usage'].first
+
+        expect(charge_usage['presentation_breakdowns'].first['units']).to eq('2.0')
+        expect(charge_usage['projected_presentation_breakdowns'].first['units']).to eq('4.0')
       end
     end
   end

--- a/spec/lago/api/resources/fee_spec.rb
+++ b/spec/lago/api/resources/fee_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Lago::Api::Resources::Fee do
         expect(fee.invoice_display_name).to eq(fee_invoice_display_name)
         expect(fee.item.invoice_display_name).to eq(fee_item_invoice_display_name)
         expect(fee.item.filter_invoice_display_name).to eq(fee_item_filter_invoice_display_name)
+        expect(fee.presentation_breakdowns.first.presentation_by.team).to eq('engineering')
       end
     end
 
@@ -76,6 +77,7 @@ RSpec.describe Lago::Api::Resources::Fee do
 
         expect(response['fees'].first['lago_id']).to eq(fee_id)
         expect(response['fees'].first['invoice_display_name']).to eq(fee_invoice_display_name)
+        expect(response['fees'].first['presentation_breakdowns'].first['units']).to eq('2.0')
       end
 
       context 'when filters are present' do

--- a/spec/lago/api/resources/plan_spec.rb
+++ b/spec/lago/api/resources/plan_spec.rb
@@ -181,6 +181,8 @@ RSpec.describe Lago::Api::Resources::Plan do
         expect(response['plans'].first['invoice_display_name']).to eq(plan_dsplay_name)
         expect(response['plans'].first['charges'].first['invoice_display_name']).to eq('Charge 1')
         expect(response['plans'].first['charges'].first['properties']['pricing_group_keys']).to eq(['agent_name'])
+        presentation_group_keys = response['plans'].first['charges'].first['properties']['presentation_group_keys']
+        expect(presentation_group_keys.first['value']).to eq('region')
         expect(response['plans'].first['minimum_commitment']['invoice_display_name']).to eq('Minimum commitment (C1)')
         expect(response['meta']['current_page']).to eq(1)
       end
@@ -436,6 +438,7 @@ RSpec.describe Lago::Api::Resources::Plan do
 
         expect(response['charges'].first['lago_id']).to eq('51c1e851-5be6-4343-a0ee-39a81d8b4ee1')
         expect(response['charges'].first['code']).to eq('charge_code')
+        expect(response['charges'].first['properties']['presentation_group_keys'].first['value']).to eq('region')
         expect(response['meta']['current_page']).to eq(1)
       end
     end
@@ -482,6 +485,7 @@ RSpec.describe Lago::Api::Resources::Plan do
 
         expect(charge.lago_id).to eq('51c1e851-5be6-4343-a0ee-39a81d8b4ee1')
         expect(charge.code).to eq(charge_code)
+        expect(charge.properties.presentation_group_keys.first.value).to eq('region')
       end
     end
 
@@ -504,7 +508,12 @@ RSpec.describe Lago::Api::Resources::Plan do
         billable_metric_id: 'a6947936-628f-4945-8857-db6858ee7941',
         code: 'charge_code',
         charge_model: 'standard',
-        properties: { amount: '0.22' },
+        properties: {
+          amount: '0.22',
+          presentation_group_keys: [
+            { value: 'region', options: { display_in_invoice: true } },
+          ],
+        },
       }
     end
 
@@ -539,7 +548,17 @@ RSpec.describe Lago::Api::Resources::Plan do
   describe '#update_charge' do
     let(:json_response) { load_fixture('plan_charge') }
     let(:charge_code) { 'charge_code' }
-    let(:params) { { invoice_display_name: 'Updated Setup' } }
+    let(:params) do
+      {
+        invoice_display_name: 'Updated Setup',
+        properties: {
+          amount: '0.22',
+          presentation_group_keys: [
+            { value: 'region', options: { display_in_invoice: true } },
+          ],
+        },
+      }
+    end
 
     context 'when charge is successfully updated' do
       before do

--- a/spec/lago/api/resources/subscription_spec.rb
+++ b/spec/lago/api/resources/subscription_spec.rb
@@ -878,6 +878,7 @@ RSpec.describe Lago::Api::Resources::Subscription do
 
         expect(response['charges'].first['lago_id']).to eq('51c1e851-5be6-4343-a0ee-39a81d8b4ee1')
         expect(response['charges'].first['code']).to eq('charge_code')
+        expect(response['charges'].first['properties']['presentation_group_keys'].first['value']).to eq('region')
         expect(response['meta']['current_page']).to eq(1)
       end
     end
@@ -910,6 +911,7 @@ RSpec.describe Lago::Api::Resources::Subscription do
 
         expect(charge.lago_id).to eq('51c1e851-5be6-4343-a0ee-39a81d8b4ee1')
         expect(charge.code).to eq(charge_code)
+        expect(charge.properties.presentation_group_keys.first.value).to eq('region')
       end
     end
 
@@ -943,7 +945,17 @@ RSpec.describe Lago::Api::Resources::Subscription do
     let(:json_response) { load_fixture('subscription_charge') }
     let(:external_subscription_id) { 'sub_123' }
     let(:charge_code) { 'charge_code' }
-    let(:params) { { invoice_display_name: 'Updated Setup' } }
+    let(:params) do
+      {
+        invoice_display_name: 'Updated Setup',
+        properties: {
+          amount: '0.22',
+          presentation_group_keys: [
+            { value: 'region', options: { display_in_invoice: true } },
+          ],
+        },
+      }
+    end
 
     context 'when charge is successfully updated' do
       before do


### PR DESCRIPTION
- Change responses and fixtures to include the presentation_breakdowns
- Update Fee to include presentation_breakdowns
- Change the current_usage to send the filter filter_by_presentation as JSON
