### PR TITLE
[ING-240] feat(wallets): add grants_target_top_up to recurring transaction rules

### DIFF
--- a/lib/lago/api/resources/customers/wallets/whitelist_params.rb
+++ b/lib/lago/api/resources/customers/wallets/whitelist_params.rb
@@ -71,6 +71,7 @@ module Lago
                   :transaction_metadata,
                   :transaction_name,
                   :ignore_paid_top_up_limits,
+                  :grants_target_top_up,
                 )
 
                 payment_method = payment_method_params(r[:payment_method])

--- a/spec/lago/api/resources/customers/wallets_spec.rb
+++ b/spec/lago/api/resources/customers/wallets_spec.rb
@@ -164,6 +164,40 @@ RSpec.describe Lago::Api::Resources::Customers::Wallets do
       end
     end
 
+    context 'when grants_target_top_up is provided in a target recurring rule' do
+      let(:params_with_grants) do
+        params.deep_merge(
+          recurring_transaction_rules: [
+            factory_wallet.recurring_transaction_rules.first.merge(
+              method: 'target',
+              target_ongoing_balance: '200',
+              grants_target_top_up: true,
+            ),
+          ],
+        )
+      end
+      let(:body_with_grants) do
+        body['wallet']['recurring_transaction_rules'].first.merge!(
+          'method' => 'target',
+          'target_ongoing_balance' => '200',
+          'grants_target_top_up' => true,
+        )
+        body
+      end
+
+      before do
+        stub_request(:post, "https://api.getlago.com/api/v1/customers/#{customer_id}/wallets")
+          .with(body: body_with_grants)
+          .to_return(body: response, status: 200)
+      end
+
+      it 'forwards grants_target_top_up in the request' do
+        wallet = resource.create(customer_id, params_with_grants)
+
+        expect(wallet.lago_id).to eq('this-is-lago-id')
+      end
+    end
+
     context 'when wallet failed to create' do
       before do
         stub_request(:post, "https://api.getlago.com/api/v1/customers/#{customer_id}/wallets")
@@ -222,6 +256,40 @@ RSpec.describe Lago::Api::Resources::Customers::Wallets do
 
         expect(wallet.lago_id).to eq('this-is-lago-id')
         expect(wallet.name).to eq(factory_wallet.name)
+      end
+    end
+
+    context 'when grants_target_top_up is provided in a target recurring rule' do
+      let(:params_with_grants) do
+        params.deep_merge(
+          recurring_transaction_rules: [
+            factory_wallet.recurring_transaction_rules.first.merge(
+              method: 'target',
+              target_ongoing_balance: '200',
+              grants_target_top_up: true,
+            ),
+          ],
+        )
+      end
+      let(:body_with_grants) do
+        body['wallet']['recurring_transaction_rules'].first.merge!(
+          'method' => 'target',
+          'target_ongoing_balance' => '200',
+          'grants_target_top_up' => true,
+        )
+        body
+      end
+
+      before do
+        stub_request(:put, "https://api.getlago.com/api/v1/customers/#{customer_id}/wallets/#{code}")
+          .with(body: body_with_grants)
+          .to_return(body: response, status: 200)
+      end
+
+      it 'forwards grants_target_top_up in the request' do
+        wallet = resource.update(customer_id, code, params_with_grants)
+
+        expect(wallet.lago_id).to eq('this-is-lago-id')
       end
     end
 


### PR DESCRIPTION
## Context

Wallet recurring transaction rules of type `target` previously always created a paid top-up; there was no way to grant free credits through a target rule. The API now supports this via a nullable boolean `grants_target_top_up` on the recurring transaction rule (getlago/lago-api#5755). On a `target` rule, `true` makes the periodic gap-fill grant free credits to reach the target balance instead of creating a paid top-up; `false`, the default for target rules, keeps the current paid behaviour. The field is `null` for `fixed` rules.

## Description

Exposes `grants_target_top_up` so consumers can set it on wallet create/update:

- Whitelists `grants_target_top_up` in the recurring transaction rule params. Responses already surface it (parsed dynamically into `OpenStruct`), so no response-model change is needed.
- Adds create and update specs asserting the field is forwarded on a target rule.

No version bump: released separately, per repo convention.

## How to try locally

```
bundle exec rspec spec/lago/api/resources/customers/wallets_spec.rb
```

