### PR TITLE
test(wallets): wait for async ongoing balance refresh

### DIFF
--- a/spec/integration/customers/wallets_spec.rb
+++ b/spec/integration/customers/wallets_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe 'Lago::Api::Client#customers.wallets', :integration do
   end
 
   def assert_wallet_attributes_with_updated_balance(wallet, **attributes)
+    # The balance is synced synchronously when the wallet transaction settles, but the ongoing
+    # balance is now refreshed by an async job (RefreshWalletJob). Re-fetch until that refresh has
+    # landed, otherwise the ongoing balance can still be 0 when the balance already reached 2000.
+    wait_until do
+      wallet = client.customers.wallets.get(wallet.external_customer_id, wallet.code)
+      wallet.ongoing_balance_cents == 2000
+    end
+
     assert_wallet_attributes(
       wallet,
       credits_balance: '10.0',

--- a/spec/integration/customers/wallets_spec.rb
+++ b/spec/integration/customers/wallets_spec.rb
@@ -54,9 +54,10 @@ RSpec.describe 'Lago::Api::Client#customers.wallets', :integration do
     # The balance is synced synchronously when the wallet transaction settles, but the ongoing
     # balance is now refreshed by an async job (RefreshWalletJob). Re-fetch until that refresh has
     # landed, otherwise the ongoing balance can still be 0 when the balance already reached 2000.
+    expected_ongoing_balance_cents = attributes.fetch(:ongoing_balance_cents, 2000)
     wait_until do
       wallet = client.customers.wallets.get(wallet.external_customer_id, wallet.code)
-      wallet.ongoing_balance_cents == 2000
+      wallet.ongoing_balance_cents == expected_ongoing_balance_cents
     end
 
     assert_wallet_attributes(

--- a/spec/integration/wallets_spec.rb
+++ b/spec/integration/wallets_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe 'Lago::Api::Client#wallets', :integration do
   end
 
   def assert_wallet_attributes_with_updated_balance(wallet, **attributes)
+    # The balance is synced synchronously when the wallet transaction settles, but the ongoing
+    # balance is now refreshed by an async job (RefreshWalletJob). Re-fetch until that refresh has
+    # landed, otherwise the ongoing balance can still be 0 when the balance already reached 2000.
+    expected_ongoing_balance_cents = attributes.fetch(:ongoing_balance_cents, 2000)
+    wait_until do
+      wallet = client.wallets.get(wallet.lago_id)
+      wallet.ongoing_balance_cents == expected_ongoing_balance_cents
+    end
+
     assert_wallet_attributes(
       wallet,
       credits_balance: '10.0',


### PR DESCRIPTION
## Context

The wallet integration tests started racing against lago-api once the ongoing balance refresh moved to an async job (getlago/lago-api#5631).

`Wallets::Balance::IncreaseService` now sets `balance_cents`, `credits_balance` and `last_balance_sync_at` in-line when the wallet transaction settles, then enqueues `RefreshWalletJob` which sets `ongoing_balance_cents` and `credits_ongoing_balance`. So once `balance_cents` reaches 2000, the ongoing balance is only eventually 2000. `assert_wallet_attributes_with_updated_balance` asserted the ongoing fields directly, so it could read a stale 0 before the async job ran.

## Description

`assert_wallet_attributes_with_updated_balance` now re-fetches the wallet until `ongoing_balance_cents` reaches 2000 before asserting. The fix sits in the assertion rather than `wait_for_balance_update` (which keeps waiting on the synchronous `balance_cents`). It's backward compatible with the synchronous behaviour: when the ongoing balance is already synced, the poll returns on the first fetch.
