### PR TITLE
[ING-70] feat(multi-entity): support billing_entity_code

### DIFF
--- a/lib/lago/api/resources/customers/wallets/whitelist_params.rb
+++ b/lib/lago/api/resources/customers/wallets/whitelist_params.rb
@@ -23,6 +23,7 @@ module Lago
                 :transaction_name,
                 :paid_top_up_min_amount_cents,
                 :paid_top_up_max_amount_cents,
+                :billing_entity_code,
               )
 
               recurring_rules = recurring_rules_params(params[:recurring_transaction_rules])

--- a/lib/lago/api/resources/invoice.rb
+++ b/lib/lago/api/resources/invoice.rb
@@ -86,7 +86,7 @@ module Lago
         def preview(params)
           path = "/api/v1/invoices/preview"
           payload = params.slice(
-            :customer, :plan_code, :subscription_at, :billing_time, :coupons, :subscriptions
+            :customer, :plan_code, :subscription_at, :billing_time, :coupons, :subscriptions, :billing_entity_code
           )
           response = connection.post(payload, path)[root_name]
 
@@ -125,8 +125,9 @@ module Lago
             external_customer_id: params[:external_customer_id],
             currency: params[:currency],
             net_payment_term: params[:net_payment_term],
-            skip_psp: params[:skip_psp]
-          }
+            skip_psp: params[:skip_psp],
+            billing_entity_code: params[:billing_entity_code]
+          }.compact
 
           fees = whitelist_fees(params[:fees])
           result[:fees] = fees unless fees.empty?

--- a/lib/lago/api/resources/subscription.rb
+++ b/lib/lago/api/resources/subscription.rb
@@ -213,6 +213,7 @@ module Lago
             ending_at: params[:ending_at],
             plan_overrides: params[:plan_overrides],
             consolidate_invoice: params[:consolidate_invoice],
+            billing_entity_code: params[:billing_entity_code],
           }.compact
 
           payment_method_params = whitelist_payment_method_params(params[:payment_method])

--- a/spec/factories/subscription.rb
+++ b/spec/factories/subscription.rb
@@ -16,5 +16,6 @@ FactoryBot.define do
     canceled_at { nil }
     created_at { '2022-05-05T12:27:30Z' }
     consolidate_invoice { true }
+    billing_entity_code { 'acme_corp' }
   end
 end

--- a/spec/integration/customers/wallets_spec.rb
+++ b/spec/integration/customers/wallets_spec.rb
@@ -73,10 +73,13 @@ RSpec.describe 'Lago::Api::Client#customers.wallets', :integration do
   end
 
   def wait_for_balance_update(wallet)
+    # balance_cents is synced synchronously when the wallet transaction settles, but the ongoing
+    # balance and pending transactions are reconciled by RefreshWalletJob. Wait for both so any
+    # subsequent destroy/assertion sees a fully settled wallet.
     new_wallet = nil
     wait_until do
       new_wallet = client.customers.wallets.get(wallet.external_customer_id, wallet.code)
-      new_wallet.balance_cents == 2000
+      new_wallet.balance_cents == 2000 && new_wallet.ongoing_balance_cents == 2000
     end
     new_wallet
   end

--- a/spec/integration/wallets_spec.rb
+++ b/spec/integration/wallets_spec.rb
@@ -71,10 +71,13 @@ RSpec.describe 'Lago::Api::Client#wallets', :integration do
   end
 
   def wait_for_balance_update(wallet_id)
+    # balance_cents is synced synchronously when the wallet transaction settles, but the ongoing
+    # balance and pending transactions are reconciled by RefreshWalletJob. Wait for both so any
+    # subsequent destroy/assertion sees a fully settled wallet.
     wallet = nil
     wait_until do
       wallet = client.wallets.get(wallet_id)
-      wallet.balance_cents == 2000
+      wallet.balance_cents == 2000 && wallet.ongoing_balance_cents == 2000
     end
     wallet
   end

--- a/spec/lago/api/resources/invoice_spec.rb
+++ b/spec/lago/api/resources/invoice_spec.rb
@@ -160,6 +160,37 @@ RSpec.describe Lago::Api::Resources::Invoice do
         end
       end
     end
+
+    context 'when billing_entity_code is provided' do
+      let(:params) do
+        {
+          external_customer_id: '_ID_',
+          currency: 'EUR',
+          net_payment_term: 0,
+          skip_psp: true,
+          billing_entity_code: 'eu_entity',
+          fees: [
+            {
+              add_on_code: '123',
+              description: 'desc',
+              tax_codes: [tax.code],
+            }
+          ]
+        }
+      end
+
+      before do
+        stub_request(:post, 'https://api.getlago.com/api/v1/invoices')
+          .with(body: { invoice: params })
+          .to_return(body: invoice_response, status: 200)
+      end
+
+      it 'returns invoice' do
+        invoice = resource.create(params)
+
+        expect(invoice.lago_id).to eq(invoice_id)
+      end
+    end
   end
 
   describe '#update' do
@@ -523,6 +554,27 @@ RSpec.describe Lago::Api::Resources::Invoice do
 
       it 'raises an error' do
         expect { subject }.to raise_error(Lago::Api::HttpError)
+      end
+    end
+
+    context 'when billing_entity_code is provided' do
+      let(:invoice_response) { load_fixture('invoice_preview') }
+      let(:params) do
+        {
+          customer: { external_id: '_ID_' },
+          plan_code: 'plan_code',
+          billing_entity_code: 'eu_entity'
+        }
+      end
+
+      before do
+        stub_request(:post, 'https://api.getlago.com/api/v1/invoices/preview')
+          .with(body: params)
+          .to_return(body: invoice_response, status: 200)
+      end
+
+      it 'forwards billing_entity_code to the preview endpoint' do
+        expect(subject).to have_attributes(lago_id: nil)
       end
     end
   end

--- a/spec/lago/api/resources/payment_request_spec.rb
+++ b/spec/lago/api/resources/payment_request_spec.rb
@@ -96,6 +96,22 @@ RSpec.describe Lago::Api::Resources::PaymentRequest do
           end
         end
 
+        context 'when billing_entity_codes is given' do
+          before do
+            stub_request(
+              :get,
+              'https://api.getlago.com/api/v1/payment_requests?billing_entity_codes%5B%5D=eu_entity&billing_entity_codes%5B%5D=us_entity',
+            ).to_return(body: payment_requests_response, status: 200)
+          end
+
+          it 'returns payment requests filtered by billing_entity_codes' do
+            response = resource.get_all({ 'billing_entity_codes[]': %w[eu_entity us_entity] })
+
+            expect(response['payment_requests'].first['lago_id']).to eq(payment_request_id)
+            expect(response['meta']['current_page']).to eq(1)
+          end
+        end
+
         context 'when there is an issue' do
           before do
             stub_request(:get, 'https://api.getlago.com/api/v1/payment_requests')

--- a/spec/lago/api/resources/subscription_spec.rb
+++ b/spec/lago/api/resources/subscription_spec.rb
@@ -196,6 +196,23 @@ RSpec.describe Lago::Api::Resources::Subscription do
         expect { resource.create(params_with_invalid_pm) }.to raise_error Lago::Api::HttpError
       end
     end
+
+    context 'when billing_entity_code is provided' do
+      let(:params_with_billing_entity) { params.merge(billing_entity_code: 'eu_entity') }
+      let(:body_with_billing_entity) { { 'subscription' => params_with_billing_entity } }
+
+      before do
+        stub_request(:post, 'https://api.getlago.com/api/v1/subscriptions')
+          .with(body: body_with_billing_entity)
+          .to_return(body: response, status: 200)
+      end
+
+      it 'returns subscription with billing_entity_code' do
+        subscription = resource.create(params_with_billing_entity)
+
+        expect(subscription.billing_entity_code).to eq(factory_subscription.billing_entity_code)
+      end
+    end
   end
 
   describe '#delete' do
@@ -356,6 +373,23 @@ RSpec.describe Lago::Api::Resources::Subscription do
         expect { resource.update(params_with_invalid_pm, '123') }.to raise_error Lago::Api::HttpError
       end
     end
+
+    context 'when billing_entity_code is provided' do
+      let(:params_with_billing_entity) { { name: 'new name', billing_entity_code: 'us_entity' } }
+      let(:body_with_billing_entity) { { 'subscription' => params_with_billing_entity } }
+
+      before do
+        stub_request(:put, 'https://api.getlago.com/api/v1/subscriptions/123')
+          .with(body: body_with_billing_entity)
+          .to_return(body: response, status: 200)
+      end
+
+      it 'returns subscription with billing_entity_code' do
+        subscription = resource.update(params_with_billing_entity, '123')
+
+        expect(subscription.billing_entity_code).to eq(factory_subscription.billing_entity_code)
+      end
+    end
   end
 
   describe '#get' do
@@ -428,6 +462,22 @@ RSpec.describe Lago::Api::Resources::Subscription do
       it 'returns subscriptions with that given status' do
         response = resource.get_all({ external_customer_id: '123', 'status[]': 'pending' })
         expect(response['subscriptions'].count).to eq(1)
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when billing_entity_codes is given' do
+      before do
+        stub_request(
+          :get,
+          'https://api.getlago.com/api/v1/subscriptions?billing_entity_codes%5B%5D=eu_entity&billing_entity_codes%5B%5D=us_entity',
+        ).to_return(body: response, status: 200)
+      end
+
+      it 'returns subscriptions filtered by billing_entity_codes' do
+        response = resource.get_all({ 'billing_entity_codes[]': %w[eu_entity us_entity] })
+
+        expect(response['subscriptions'].first['lago_id']).to eq(factory_subscription.lago_id)
         expect(response['meta']['current_page']).to eq(1)
       end
     end

--- a/spec/lago/api/resources/wallet_spec.rb
+++ b/spec/lago/api/resources/wallet_spec.rb
@@ -333,6 +333,42 @@ RSpec.describe Lago::Api::Resources::Wallet do
         end
       end
     end
+
+    context 'when billing_entity_code is provided' do
+      let(:params_with_billing_entity) { params.merge(billing_entity_code: 'eu_entity') }
+      let(:body_with_billing_entity) do
+        body['wallet']['billing_entity_code'] = 'eu_entity'
+        body
+      end
+      let(:response_with_billing_entity) do
+        {
+          'wallet' => {
+            'lago_id' => 'this-is-lago-id',
+            'lago_customer_id' => factory_wallet.id,
+            'name' => factory_wallet.name,
+            'billing_entity_code' => 'eu_entity',
+            'expiration_at' => factory_wallet.expiration_at,
+            'balance_cents' => 10_000,
+            'rate_amount' => factory_wallet.rate_amount,
+            'created_at' => '2022-04-29T08:59:51Z',
+            'recurring_transaction_rules' => factory_wallet.recurring_transaction_rules,
+            'applies_to' => factory_wallet.applies_to,
+          }
+        }.to_json
+      end
+
+      before do
+        stub_request(:post, 'https://api.getlago.com/api/v1/wallets')
+          .with(body: body_with_billing_entity)
+          .to_return(body: response_with_billing_entity, status: 200)
+      end
+
+      it 'returns a wallet with billing_entity_code' do
+        wallet = resource.create(params_with_billing_entity)
+
+        expect(wallet.billing_entity_code).to eq('eu_entity')
+      end
+    end
   end
 
   describe '#update' do
@@ -671,6 +707,22 @@ RSpec.describe Lago::Api::Resources::Wallet do
 
         expect(response['wallets'].first['lago_id']).to eq('this-is-lago-id')
         expect(response['wallets'].first['name']).to eq(factory_wallet.name)
+        expect(response['meta']['current_page']).to eq(1)
+      end
+    end
+
+    context 'when billing_entity_codes is given' do
+      before do
+        stub_request(
+          :get,
+          'https://api.getlago.com/api/v1/wallets?billing_entity_codes%5B%5D=eu_entity&billing_entity_codes%5B%5D=us_entity',
+        ).to_return(body: response, status: 200)
+      end
+
+      it 'returns wallets filtered by billing_entity_codes' do
+        response = resource.get_all({ 'billing_entity_codes[]': %w[eu_entity us_entity] })
+
+        expect(response['wallets'].first['lago_id']).to eq('this-is-lago-id')
         expect(response['meta']['current_page']).to eq(1)
       end
     end


### PR DESCRIPTION
## Context

Multi-Entity Billing lets a customer's resources be scoped to a billing entity other than their default. The Ruby client needs to forward the optional `billing_entity_code` request param on writes, surface it on the response side, and accept the `billing_entity_codes` filter on list endpoints so callers can target a specific entity.

**Closes ING-70 but will not be merged until the feature is 100% released to clients.**

## Changes

**Request params — `billing_entity_code` (String)** added to:

- `POST /subscriptions` and `PUT /subscriptions/:external_id` — shared `Subscription#whitelist_params`, so create and update both pick it up.
- `POST /wallets` (and `POST /customers/:id/wallets` via the same `Customers::Wallets::WhitelistParams`).
- `POST /invoices` (one-off) — `Invoice#one_off_params`, now `.compact`ed so the new optional field is dropped from the JSON when unset.
- `POST /invoices/preview` — added to the `preview` slice.

When omitted, the API falls back to the customer's billing entity, so existing callers are unaffected.

**Response read-back** — Subscription and Wallet response objects expose `billing_entity_code` automatically through the client's `JSON.parse(..., object_class: OpenStruct)` deserialization. No production change required; the subscription factory carries the field so existing-response specs read it back, and dedicated wallet/subscription contexts assert it round-trips. Invoice and CreditNote already exposed it.

**List filters — `billing_entity_codes[]` (Array<String>)** for:

- `GET /subscriptions`, `GET /wallets`, `GET /payment_requests`.

`Connection#get_all` already forwards arbitrary options through `URI.encode_www_form`, following the existing `'status[]'` convention, so this is a test-only change on the client side — specs lock in the query-string shape (`billing_entity_codes%5B%5D=…`). `GET /invoices` and `GET /credit_notes` already worked.

## Tests

Targeted specs added:

- `spec/lago/api/resources/subscription_spec.rb` — create / update with `billing_entity_code`; `get_all` with `billing_entity_codes[]`.
- `spec/lago/api/resources/wallet_spec.rb` — create with `billing_entity_code` (asserts read-back); `get_all` with `billing_entity_codes[]`.
- `spec/lago/api/resources/invoice_spec.rb` — create with `billing_entity_code`; preview with `billing_entity_code`.
- `spec/lago/api/resources/payment_request_spec.rb` — `get_all` with `billing_entity_codes[]`.

```
bundle exec rspec --exclude-pattern "spec/integration/**/*"
# 538 examples, 0 failures
```
