### PR TITLE
test(wallets): wait for async ongoing balance refresh

### DIFF
--- a/spec/integration/customers/wallets_spec.rb
+++ b/spec/integration/customers/wallets_spec.rb
@@ -51,6 +51,15 @@ RSpec.describe 'Lago::Api::Client#customers.wallets', :integration do
   end
 
   def assert_wallet_attributes_with_updated_balance(wallet, **attributes)
+    # balance_cents is synced synchronously when the wallet transaction settles, but
+    # ongoing_balance_cents is refreshed by an async job (RefreshWalletJob), so re-fetch
+    # until the ongoing refresh has landed before asserting.
+    expected_ongoing_balance_cents = attributes.fetch(:ongoing_balance_cents, 2000)
+    wait_until do
+      wallet = client.customers.wallets.get(wallet.external_customer_id, wallet.code)
+      wallet.ongoing_balance_cents == expected_ongoing_balance_cents
+    end
+
     assert_wallet_attributes(
       wallet,
       credits_balance: '10.0',

--- a/spec/integration/wallets_spec.rb
+++ b/spec/integration/wallets_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe 'Lago::Api::Client#wallets', :integration do
   end
 
   def assert_wallet_attributes_with_updated_balance(wallet, **attributes)
+    # balance_cents is synced synchronously when the wallet transaction settles, but
+    # ongoing_balance_cents is refreshed by an async job (RefreshWalletJob), so re-fetch
+    # until the ongoing refresh has landed before asserting.
+    expected_ongoing_balance_cents = attributes.fetch(:ongoing_balance_cents, 2000)
+    wait_until do
+      wallet = client.wallets.get(wallet.lago_id)
+      wallet.ongoing_balance_cents == expected_ongoing_balance_cents
+    end
+
     assert_wallet_attributes(
       wallet,
       credits_balance: '10.0',


### PR DESCRIPTION
## Context

Six wallet integration tests (`#update`, `#get`, `#get_all` on both `spec/integration/wallets_spec.rb` and `spec/integration/customers/wallets_spec.rb`) fail in CI with `expected: "10.0", got: "0.0"` on `credits_ongoing_balance`.

`balance_cents` is updated synchronously when the wallet transaction settles, but `ongoing_balance_cents` / `credits_ongoing_balance` are refreshed by an async `RefreshWalletJob`. The existing `wait_for_balance_update` only polls until `balance_cents == 2000`, so the assertions can run before the ongoing refresh has landed and the wallet still reports `0.0` for the ongoing fields.

## Fix

Adds a second wait inside `assert_wallet_attributes_with_updated_balance` that re-fetches the wallet until `ongoing_balance_cents` matches the expected value before asserting. The expected value is read from the optional `ongoing_balance_cents` override (default `2000`), so tests that pass a custom override continue to drive the wait correctly.

```ruby
expected_ongoing_balance_cents = attributes.fetch(:ongoing_balance_cents, 2000)
wait_until do
  wallet = client.wallets.get(wallet.lago_id)   # client.customers.wallets.get(...) in the nested file
  wallet.ongoing_balance_cents == expected_ongoing_balance_cents
end
```

Same shape applied to both the top-level (`wallets_spec.rb`) and customer-scoped (`customers/wallets_spec.rb`) helpers.

## Tests

```
docker compose exec client bundle exec rspec \
  spec/integration/wallets_spec.rb \
  spec/integration/customers/wallets_spec.rb
```

All ten previously-failing examples pass; no regressions in the surrounding suites. The `#destroy` flake that occasionally surfaces when the two files run back-to-back is unrelated (HTTP 409 from leftover Lago state), passes in isolation, and was already green before this branch.
